### PR TITLE
Implement pause menu with key listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ Jogo educativo casual de reflexo que desafia crianças e adultos a identificar e
    * Toque em itens seguros para ganhar pontos.
    * Evite itens com alérgenos marcados no seu perfil.
    * Cada erro reduz uma vida; zero vidas encerra o jogo.
+   * Aperte **P** ou o botão "Pausar" para abrir o menu de pausa.
 4. **Pontuação**: +10 pontos por acerto.
 5. **Fim de Jogo**: Veja seu resultado e reinicie.
 


### PR DESCRIPTION
## Summary
- add a pause button and "P" key handler in `GameScene`
- create new `PauseScene` for resume and exit actions
- wire pause scene into `MemoryGame` initialization
- document pause controls in README

## Testing
- `npm test -- --watchAll=false --passWithNoTests`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688ab3a14d38832faaf6d23ac858e7ba