### PR TITLE
Expand allergens support

### DIFF
--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -10,7 +10,9 @@ const ALLERGEN_NAMES = [
   'Soja',
   'Trigo',
   'Peixes',
-  'Frutos do Mar'
+  'Frutos do Mar',
+  'Castanhas',
+  'Milho'
 ];
 
 /**
@@ -33,7 +35,8 @@ export default function Profile() {
   }
 
   // Compute a list of allergens from the bitmask for display.
-  const selected = ALLERGEN_NAMES.filter((_, idx) => (profile.bitmask & (1 << idx)) !== 0);
+  const bitCount = profile.bitCount || ALLERGEN_NAMES.length;
+  const selected = ALLERGEN_NAMES.slice(0, bitCount).filter((_, idx) => (profile.bitmask & (1 << idx)) !== 0);
 
   return (
     <div style={{ padding: '2rem' }}>

--- a/src/components/Register.js
+++ b/src/components/Register.js
@@ -3,7 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { saveProfile, loadProfile } from '../services/firestore';
 import { saveLocalProfile } from '../utils/storage';
 
-// Define the names of the seven major allergens used in the bitmask.
+// Define the names of the allergens used in the bitmask.
 const ALLERGENS = [
   { name: 'Leite', bit: 0 },
   { name: 'Ovo', bit: 1 },
@@ -11,7 +11,9 @@ const ALLERGENS = [
   { name: 'Soja', bit: 3 },
   { name: 'Trigo', bit: 4 },
   { name: 'Peixes', bit: 5 },
-  { name: 'Frutos do Mar', bit: 6 }
+  { name: 'Frutos do Mar', bit: 6 },
+  { name: 'Castanhas', bit: 7 },
+  { name: 'Milho', bit: 8 }
 ];
 
 /**
@@ -19,7 +21,7 @@ const ALLERGENS = [
  *
  * Allows the player to enter their name and age and select which
  * allergens they need to avoid.  The selected allergens are stored
- * in a 7‑bit bitmask.  Upon submission the profile is persisted to
+ * in a bitmask.  Upon submission the profile is persisted to
  * Firebase (via the firestore service) and to local storage.
  */
 export default function Register() {
@@ -49,7 +51,13 @@ export default function Register() {
   const handleSubmit = async (e) => {
     e.preventDefault();
     // Compose the profile object.
-    const profile = { uid: Date.now().toString(), nome: name, idade: age, bitmask };
+    const profile = {
+      uid: Date.now().toString(),
+      nome: name,
+      idade: age,
+      bitmask,
+      bitCount: ALLERGENS.length
+    };
     try {
       await saveProfile(profile);
       saveLocalProfile(profile);

--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -20,7 +20,7 @@
     {
       "key": "hazelnut",
       "spriteUrl": "/assets/images/hazelnut.png",
-      "bitmaskBit": 2
+      "bitmaskBit": 7
     }
   ]
 }

--- a/src/utils/bitmask.js
+++ b/src/utils/bitmask.js
@@ -1,5 +1,5 @@
 /**
- * Utility functions for working with a 7‑bit allergen bitmask.
+ * Utility functions for working with an allergen bitmask.
  * Each bit corresponds to a particular allergen as defined in
  * components/Register.js.  A bit value of 1 indicates the player
  * should avoid that allergen.
@@ -40,9 +40,9 @@ export function removeAllergen(mask, bit) {
  * @param {number} mask
  * @returns {number[]}
  */
-export function bitmaskToArray(mask) {
+export function bitmaskToArray(mask, bitCount = 7) {
   const bits = [];
-  for (let i = 0; i < 7; i++) {
+  for (let i = 0; i < bitCount; i++) {
     if (hasAllergen(mask, i)) bits.push(i);
   }
   return bits;


### PR DESCRIPTION
## Summary
- update bitmask utilities to use a dynamic bit count
- include new `Castanhas` and `Milho` allergens
- store bit count with saved profiles and respect it when displaying data
- mark `hazelnut` as `Castanhas` in the `feira` phase

## Testing
- `CI=true npm test --silent -- --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_688b9810ff20832f8ffd90580a60ae2f