### PR TITLE
Add startup redirect logic

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,7 @@ import ModeSelect from './components/ModeSelect';
 import Tutorial from './components/Tutorial';
 import MemoryGame from './components/MemoryGame';
 import Intro from './components/Intro';
+import StartupRedirect from './components/StartupRedirect';
 
 /**
  * The top level application component.  It defines the routes
@@ -18,7 +19,8 @@ import Intro from './components/Intro';
 export default function App() {
   return (
     <Routes>
-      <Route path="/" element={<Intro />} />
+      <Route path="/" element={<StartupRedirect />} />
+      <Route path="/intro" element={<Intro />} />
       <Route path="/register" element={<Register />} />
       <Route path="/profile" element={<Profile />} />
       <Route path="/modes" element={<ModeSelect />} />

--- a/src/components/StartupRedirect.js
+++ b/src/components/StartupRedirect.js
@@ -1,0 +1,25 @@
+import React, { useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { loadProfile } from '../services/firestore';
+
+/**
+ * Component that checks for an existing profile on load and
+ * redirects the user accordingly. If a profile is found, the
+ * player is taken directly to the mode selection screen.
+ * Otherwise we send them to registration to create a profile.
+ */
+export default function StartupRedirect() {
+  const navigate = useNavigate();
+  useEffect(() => {
+    (async () => {
+      const profile = await loadProfile();
+      if (profile) {
+        navigate('/modes', { replace: true });
+      } else {
+        navigate('/register', { replace: true });
+      }
+    })();
+  }, [navigate]);
+
+  return <div style={{ padding: '2rem' }}>Carregando…</div>;
+}


### PR DESCRIPTION
## Summary
- route `/` to a StartupRedirect component
- add StartupRedirect component
- keep Intro at `/intro`

## Testing
- `npm test -- --watchAll=false --passWithNoTests`

------
https://chatgpt.com/codex/tasks/task_b_688d0b3fec68832f986ad62f9391416f