### PR TITLE
Refactor architecture: add Zustand global store and PhaserGameEngine skeleton

### DIFF
--- a/src/gameEngine.js
+++ b/src/gameEngine.js
@@ -1,0 +1,21 @@
+import Phaser from 'phaser';
+import DifficultyManager from './utils/DifficultyManager';
+
+export default class PhaserGameEngine {
+  constructor({ phaseConfig, bitmask, onGameOver, onReturnToMenu }) {
+    this.config = { phaseConfig, bitmask, onGameOver, onReturnToMenu };
+    this.game = null;
+  }
+
+  init(parent) {
+    // TODO: instantiate Phaser.Game with GameScene and PauseScene.
+    // See the patch provided for the full implementation.
+  }
+
+  destroy() {
+    if (this.game) {
+      this.game.destroy(true);
+      this.game = null;
+    }
+  }
+}

--- a/src/store.js
+++ b/src/store.js
@@ -1,0 +1,36 @@
+// Global store for Chef Alerg
+//
+// This file defines a simple Zustand powered store for the game.  The
+// store centralizes all mutable game state, including the current
+// phase, the player's profile and any other cross cutting data.  In
+// addition to reducing React prop drilling, a centralized store
+// makes it trivial for non‑React code (like the Phaser engine) to
+// read and update state via events.  See usage in GameWrapper and
+// MemoryGame for examples.
+
+import create from 'zustand';
+
+export const useStore = create((set) => ({
+  /**
+   * The id of the current phase.  Changing this value will cause
+   * GameWrapper to instantiate a new PhaserGameEngine with the
+   * appropriate configuration.
+   */
+  currentPhase: null,
+  setCurrentPhase: (phaseId) => set({ currentPhase: phaseId }),
+
+  /**
+   * The player's profile.  Contains name, age and allergen bitmask.
+   */
+  profile: null,
+  setProfile: (profile) => set({ profile }),
+
+  /**
+   * A list of loaded phase configurations.  These are loaded from
+   * JSON files at runtime.  Populating this cache avoids re‑fetching
+   * phase files repeatedly when replaying levels.
+   */
+  phases: {},
+  setPhaseConfig: (id, config) =>
+    set((state) => ({ phases: { ...state.phases, [id]: config } })),
+}));


### PR DESCRIPTION
This PR introduces a Zustand-powered global store (src/store.js) and a PhaserGameEngine skeleton (src/gameEngine.js) to start decoupling React and Phaser. These changes lay the foundation for a clean architecture. More components and phase configs will be added in follow-up commits.