### PR TITLE
Fix bitmask conversion and add tests

### DIFF
--- a/src/utils/bitmask.js
+++ b/src/utils/bitmask.js
@@ -37,12 +37,25 @@ export function removeAllergen(mask, bit) {
 
 /**
  * Convert a bitmask into an array of bit indices that are set.
+ *
+ * If `bitCount` is not provided, the function will inspect the mask and
+ * iterate only over the bits necessary to represent it.  The previous
+ * implementation defaulted to a hard coded bit count of 7 which meant any
+ * allergens represented by higher bits (e.g. bit 8 for "Milho") were ignored.
+ *
  * @param {number} mask
+ * @param {number} [bitCount] optional number of bits to inspect
  * @returns {number[]}
  */
-export function bitmaskToArray(mask, bitCount = 7) {
+export function bitmaskToArray(mask, bitCount) {
+  const count =
+    typeof bitCount === 'number'
+      ? bitCount
+      : mask === 0
+      ? 0
+      : Math.floor(Math.log2(mask)) + 1;
   const bits = [];
-  for (let i = 0; i < bitCount; i++) {
+  for (let i = 0; i < count; i++) {
     if (hasAllergen(mask, i)) bits.push(i);
   }
   return bits;

--- a/src/utils/bitmask.test.js
+++ b/src/utils/bitmask.test.js
@@ -1,0 +1,22 @@
+import { hasAllergen, addAllergen, removeAllergen, bitmaskToArray, arrayToBitmask } from './bitmask';
+
+describe('bitmask utilities', () => {
+  test('handles setting and removing allergens', () => {
+    let mask = 0;
+    mask = addAllergen(mask, 2);
+    expect(hasAllergen(mask, 2)).toBe(true);
+    mask = removeAllergen(mask, 2);
+    expect(hasAllergen(mask, 2)).toBe(false);
+  });
+
+  test('converts bitmask with high bits to array', () => {
+    // set bits 3 and 8 to ensure we exercise bits above the previous default
+    let mask = 0;
+    mask = addAllergen(mask, 3);
+    mask = addAllergen(mask, 8);
+
+    expect(bitmaskToArray(mask)).toEqual([3, 8]);
+    expect(arrayToBitmask([3, 8])).toBe(mask);
+  });
+});
+


### PR DESCRIPTION
## Summary
- fix bitmaskToArray to handle arbitrary bit counts
- add unit tests for bitmask utilities

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_688e5919aa60832fb50cf5ab27a1d812