### PR TITLE
Add loading indicator to memory game

### DIFF
--- a/src/components/LoadingScreen.js
+++ b/src/components/LoadingScreen.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+/**
+ * LoadingScreen
+ *
+ * Displayed while game assets such as the phase configuration or
+ * player profile bitmask are being loaded.  Keeps the user informed
+ * that something is happening instead of rendering nothing.
+ */
+export default function LoadingScreen() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100%',
+        fontSize: '1.5rem',
+      }}
+    >
+      Carregando...
+    </div>
+  );
+}

--- a/src/components/MemoryGame.js
+++ b/src/components/MemoryGame.js
@@ -1,6 +1,7 @@
 import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import GameWrapper from './GameWrapper';
+import LoadingScreen from './LoadingScreen';
 import { useStore } from '../store';
 import { loadProfile } from '../services/firestore';
 
@@ -17,7 +18,7 @@ export default function MemoryGame() {
   const { phase } = useParams();
   const navigate   = useNavigate();
   const [phaseConfig, setPhaseConfig] = useState(null);
-  const [bitmask, setBitmask]         = useState(0);
+  const [bitmask, setBitmask]         = useState(null);
   const setCurrentPhase               = useStore((s) => s.setCurrentPhase);
 
   // Load phase JSON on mount or when the route param changes.
@@ -38,8 +39,13 @@ export default function MemoryGame() {
   // Load the player's allergen bitmask from remote storage.
   useEffect(() => {
     (async () => {
-      const profile = await loadProfile();
-      setBitmask(profile?.bitmask || 0);
+      try {
+        const profile = await loadProfile();
+        setBitmask(profile?.bitmask || 0);
+      } catch (err) {
+        console.error('Erro ao carregar o perfil', err);
+        setBitmask(0);
+      }
     })();
   }, []);
 
@@ -50,7 +56,7 @@ export default function MemoryGame() {
     handleReturnToMenu();
   };
 
-  if (!phaseConfig) return null;
+  if (!phaseConfig || bitmask === null) return <LoadingScreen />;
   return (
     <GameWrapper
       phaseConfig={phaseConfig}


### PR DESCRIPTION
## Summary
- add LoadingScreen component with simple message
- use LoadingScreen in MemoryGame until phase data and bitmask are ready

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_688e64618b60832f8c4fe195b883575e