### PR TITLE
feat: add thumbnails and grid layout for phase selection

### DIFF
--- a/src/components/ModeSelect.js
+++ b/src/components/ModeSelect.js
@@ -1,12 +1,17 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
+// Thumbnails for each phase
+import feiraImg from '../assets/images/apple.png';
+import supermercadoImg from '../assets/images/bread.png';
+import festaImg from '../assets/images/cake.png';
+
 // List of available phases.  The key matches the JSON file name in
 // `src/phases/` and the label is shown to the player.
 const PHASES = [
-  { key: 'feira', label: 'Feira de Rua' },
-  { key: 'supermercado', label: 'Supermercado' },
-  { key: 'festa', label: 'Festa de Aniversário' }
+  { key: 'feira', label: 'Feira de Rua', img: feiraImg, alt: 'Banca de feira' },
+  { key: 'supermercado', label: 'Supermercado', img: supermercadoImg, alt: 'Corredor de supermercado' },
+  { key: 'festa', label: 'Festa de Aniversário', img: festaImg, alt: 'Bolo de festa' }
 ];
 
 export default function ModeSelect() {
@@ -15,13 +20,19 @@ export default function ModeSelect() {
   return (
     <div style={{ padding: '2rem' }}>
       <h1>Escolha uma Fase</h1>
-      <ul style={{ listStyle: 'none', padding: 0 }}>
-        {PHASES.map(({ key, label }) => (
-          <li key={key} style={{ margin: '0.5rem 0' }}>
-            <button onClick={() => navigate(`/play/${key}`)}>{label}</button>
-          </li>
+      <div className="phase-grid">
+        {PHASES.map(({ key, label, img, alt }) => (
+          <button
+            key={key}
+            className="phase-button"
+            onClick={() => navigate(`/play/${key}`)}
+            aria-label={label}
+          >
+            <img src={img} alt={alt || label} />
+            <span>{label}</span>
+          </button>
         ))}
-      </ul>
+      </div>
     </div>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -12,3 +12,38 @@ body {
   display: flex;
   flex-direction: column;
 }
+
+.phase-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  padding: 0;
+  margin: 0;
+}
+
+.phase-button {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 2px solid #ccc;
+  background-color: #fff;
+  padding: 0.5rem;
+  border-radius: 8px;
+  cursor: pointer;
+  transition: transform 0.2s, border-color 0.2s;
+}
+
+.phase-button:hover,
+.phase-button:focus {
+  border-color: #007bff;
+  transform: scale(1.05);
+  outline: none;
+}
+
+.phase-button img {
+  width: 80px;
+  height: 80px;
+  object-fit: contain;
+  margin-bottom: 0.5rem;
+}


### PR DESCRIPTION
## Summary
- render phase options in a responsive grid
- show thumbnail images for each phase
- add button hover/focus styles for accessibility

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_688e6613f5dc832f8e6f3e67dd09a06d