### PR TITLE
fix: handle corrupted profile storage and add tests

### DIFF
--- a/src/utils/storage.js
+++ b/src/utils/storage.js
@@ -24,9 +24,16 @@ export function saveLocalProfile(profile) {
 export function loadLocalProfile() {
   try {
     const data = localStorage.getItem(PROFILE_KEY);
-    return data ? JSON.parse(data) : null;
+    if (!data) return null;
+    return JSON.parse(data);
   } catch (err) {
     console.warn('Unable to load profile from local storage', err);
+    try {
+      // Remove any corrupted data so future calls don't keep failing
+      localStorage.removeItem(PROFILE_KEY);
+    } catch (_) {
+      /* ignore */
+    }
     return null;
   }
 }

--- a/src/utils/storage.test.js
+++ b/src/utils/storage.test.js
@@ -1,0 +1,25 @@
+import { saveLocalProfile, loadLocalProfile } from './storage';
+
+describe('storage utilities', () => {
+  const KEY = 'chefAlergProfile';
+
+  afterEach(() => {
+    localStorage.clear();
+  });
+
+  test('saves and loads profile', () => {
+    const profile = { name: 'Ana', bitmask: 3 };
+    saveLocalProfile(profile);
+    expect(localStorage.getItem(KEY)).toBe(JSON.stringify(profile));
+    expect(loadLocalProfile()).toEqual(profile);
+  });
+
+  test('returns null and clears invalid data', () => {
+    localStorage.setItem(KEY, 'not-json');
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    const loaded = loadLocalProfile();
+    expect(loaded).toBeNull();
+    expect(localStorage.getItem(KEY)).toBeNull();
+    warnSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
## Summary
- handle invalid JSON in `loadLocalProfile` and clear corrupted entry
- add unit tests for storage utilities

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_688e74d687c8832f95d0dae2d8d1152b