### PR TITLE
Fix GameWrapper component syntax

### DIFF
--- a/src/components/GameWrapper.js
+++ b/src/components/GameWrapper.js
@@ -1,21 +1,24 @@
 import React, { useEffect, useRef } from 'react';
 import PhaserGameEngine from '../gameEngine';
 
-
+/**
+ * Wraps the Phaser game engine inside a React component. Whenever the
+ * provided phase configuration or bitmask changes, the PhaserGameEngine is
+ * re-initialized. Game over and menu return events are bubbled up through the
+ * supplied callbacks so routing logic can respond appropriately.
+ */
 export default function GameWrapper({ phaseConfig, bitmask, onGameOver, onReturnToMenu }) {
   const containerRef = useRef(null);
   const engineRef = useRef(null);
 
   useEffect(() => {
     if (!phaseConfig || !containerRef.current) return;
-    // Create a new game engine instance for this phase
+    // Create a new game engine for this phase
     engineRef.current = new PhaserGameEngine({ phaseConfig, bitmask, onGameOver, onReturnToMenu });
     engineRef.current.init(containerRef.current);
     return () => {
-      if (engineRef.current) {
-        engineRef.current.destroy();
-        engineRef.current = null;
-      }
+      engineRef.current?.destroy();
+      engineRef.current = null;
     };
   }, [phaseConfig, bitmask, onGameOver, onReturnToMenu]);
 
@@ -27,26 +30,3 @@ export default function GameWrapper({ phaseConfig, bitmask, onGameOver, onReturn
   );
 }
 
- * This React component wraps the Phaser engine and ties it into the
- * lifecycle of React.  When the provided phase configuration or
- * bitmask changes, the wrapper re‑initializes the PhaserGameEngine.
- * The `onGameOver` and `onReturnToMenu` callbacks bubble events
- * up to the parent so that routing logic can respond appropriately.
- */
-export default function GameWrapper({ phaseConfig, bitmask, onGameOver, onReturnToMenu }) {
-  const containerRef = useRef(null);
-  const engineRef    = useRef(null);
-
-  useEffect(() => {
-    if (!phaseConfig || !containerRef.current) return;
-    // Create a new game engine for this phase.
-    engineRef.current = new PhaserGameEngine({ phaseConfig, bitmask, onGameOver, onReturnToMenu });
-    engineRef.current.init(containerRef.current);
-    return () => {
-      engineRef.current?.destroy();
-      engineRef.current = null;
-    };
-  }, [phaseConfig, bitmask, onGameOver, onReturnToMenu]);
-
-  return <div ref={containerRef} style={{ width: '100%', height: '100%', touchAction: 'none' }} />;
-}


### PR DESCRIPTION
## Summary
- clean up duplicate GameWrapper implementation and malformed comment

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_688e7b2e5050832fb7099797a1b6e57c