### PR TITLE
fix: update phase thumbnails paths

### DIFF
--- a/src/components/ModeSelect.js
+++ b/src/components/ModeSelect.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 
 // Thumbnails for each phase
-import feiraImg from '../assets/images/apple.png';
-import supermercadoImg from '../assets/images/bread.png';
-import festaImg from '../assets/images/cake.png';
+import feiraImg from '../assets/images/items/apple.png';
+import supermercadoImg from '../assets/images/items/bread.png';
+import festaImg from '../assets/images/items/cake.png';
 
 // List of available phases.  The key matches the JSON file name in
 // `src/phases/` and the label is shown to the player.


### PR DESCRIPTION
## Summary
- update ModeSelect thumbnails to point to item images

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_688f753bba78832f96d721d2d3f632db