### PR TITLE
Include items directory in phase sprite URLs

### DIFF
--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -4,22 +4,22 @@
   "items": [
     {
       "key": "apple",
-      "spriteUrl": "/assets/images/apple.png",
+      "spriteUrl": "/assets/images/items/apple.png",
       "bitmaskBit": 0
     },
     {
       "key": "banana",
-      "spriteUrl": "/assets/images/banana.png",
+      "spriteUrl": "/assets/images/items/banana.png",
       "bitmaskBit": 0
     },
     {
       "key": "peanut",
-      "spriteUrl": "/assets/images/peanut.png",
+      "spriteUrl": "/assets/images/items/peanut.png",
       "bitmaskBit": 2
     },
     {
       "key": "hazelnut",
-      "spriteUrl": "/assets/images/hazelnut.png",
+      "spriteUrl": "/assets/images/items/hazelnut.png",
       "bitmaskBit": 7
     }
   ]

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -4,22 +4,22 @@
   "items": [
     {
       "key": "cake",
-      "spriteUrl": "/assets/images/cake.png",
+      "spriteUrl": "/assets/images/items/cake.png",
       "bitmaskBit": 1
     },
     {
       "key": "icecream",
-      "spriteUrl": "/assets/images/icecream.png",
+      "spriteUrl": "/assets/images/items/icecream.png",
       "bitmaskBit": 0
     },
     {
       "key": "chocolate",
-      "spriteUrl": "/assets/images/chocolate.png",
+      "spriteUrl": "/assets/images/items/chocolate.png",
       "bitmaskBit": 2
     },
     {
       "key": "candy",
-      "spriteUrl": "/assets/images/candy.png",
+      "spriteUrl": "/assets/images/items/candy.png",
       "bitmaskBit": 0
     }
   ]

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -4,23 +4,23 @@
   "items": [
     {
       "key": "cookie",
-      "spriteUrl": "/assets/images/cookie.png",
+      "spriteUrl": "/assets/images/items/cookie.png",
       "bitmaskBit": 1
     },
     {
       "key": "milk",
-      "spriteUrl": "/assets/images/milk.png",
+      "spriteUrl": "/assets/images/items/milk.png",
       "bitmaskBit": 0
     },
     {
       "key": "bread",
-      "spriteUrl": "/assets/images/bread.png",
+      "spriteUrl": "/assets/images/items/bread.png",
       "bitmaskBit": 4,
       "trap": true
     },
     {
       "key": "cereal",
-      "spriteUrl": "/assets/images/cereal.png",
+      "spriteUrl": "/assets/images/items/cereal.png",
       "bitmaskBit": 4
     }
   ]


### PR DESCRIPTION
## Summary
- update `spriteUrl` paths in `feira`, `festa`, and `supermercado` phase files to reference the `/assets/images/items` directory

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_688f76cb304c832f93d8d9d4c59b18e6