### PR TITLE
Adjust spawn to drop items from above

### DIFF
--- a/src/gameEngine.js
+++ b/src/gameEngine.js
@@ -112,7 +112,7 @@ export default class PhaserGameEngine {
         this.lastSpawn = time;
         const item = Phaser.Math.RND.pick(phaseConfig.items);
         const x = Phaser.Math.Between(50, this.scale.width - 50);
-        const y = Phaser.Math.Between(100, this.scale.height - 50);
+        const y = -50;
         const sprite = this.add.image(x, y, item.key);
         sprite.setData('bit', item.bitmaskBit || 0);
         sprite.setInteractive();


### PR DESCRIPTION
## Summary
- spawn items off-screen and tween downwards so they fall into view

## Testing
- `npm test -- --watchAll=false`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_688f9e512cc8832fb7fe3e9e0c866a4b