### PR TITLE
chore: add background images to phases

### DIFF
--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -1,4 +1,5 @@
 {
+  "background": "/assets/images/bg/feira_day.png",
   "spawnRate": 1500,
   "simultaneous": 2,
   "items": [

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -1,4 +1,5 @@
 {
+  "background": "/assets/images/bg/festa.png",
   "spawnRate": 1000,
   "simultaneous": 3,
   "items": [

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -1,4 +1,5 @@
 {
+  "background": "/assets/images/bg/supermercado.png",
   "spawnRate": 1400,
   "simultaneous": 3,
   "items": [


### PR DESCRIPTION
## Summary
- add `background` references for `feira`, `festa`, and `supermercado` phases

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_6890abbfbabc832f854209f1c4cdbb68