### PR TITLE
feat: expand phases with bonus and new allergens

### DIFF
--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -13,7 +13,10 @@ const ALLERGEN_NAMES = [
   'Peixes',
   'Frutos do Mar',
   'Castanhas',
-  'Milho'
+  'Milho',
+  'Coco',
+  'Abacaxi',
+  'Morango'
 ];
 
 /**

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -15,6 +15,9 @@ const ALLERGEN_NAMES = [
   'Frutos do Mar',
   'Castanhas',
   'Milho',
+  'Coco',
+  'Abacaxi',
+  'Morango',
 ];
 
 // Gera um UID simples combinando timestamp e número aleatório.

--- a/src/gameEngine.js
+++ b/src/gameEngine.js
@@ -152,14 +152,20 @@ export default class PhaserGameEngine {
       handleItemClick(sprite) {
         const item = sprite.getData('itemData');
         const bit = item.bitmaskBit;
-        const isAllergen = (bitmask & (1 << bit)) !== 0;
+        const isAllergen =
+          typeof bit === 'number' && (bitmask & (1 << bit)) !== 0;
         if (isAllergen) {
           this.lives -= 1;
           this.sound.play('allergenSound');
           this.updateLives();
           this.showTip();
+        } else if (item.trap) {
+          this.score = Math.max(0, this.score - (item.penalty || 10));
+          this.sound.play('allergenSound');
+          this.updateScore();
         } else {
-          this.score += 10;
+          const bonus = item.bonus || 0;
+          this.score += 10 + bonus;
           this.sound.play('safeSound');
           this.updateScore();
         }

--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -4,13 +4,11 @@
   "items": [
     {
       "key": "apple",
-      "spriteUrl": "/assets/images/items/apple.png",
-      "bitmaskBit": 0
+      "spriteUrl": "/assets/images/items/apple.png"
     },
     {
       "key": "banana",
       "spriteUrl": "/assets/images/items/banana.png",
-      "bitmaskBit": 0,
       "trap": true,
       "penalty": 5
     },
@@ -23,6 +21,16 @@
       "key": "hazelnut",
       "spriteUrl": "/assets/images/items/hazelnut.png",
       "bitmaskBit": 7
+    },
+    {
+      "key": "soybean",
+      "spriteUrl": "/assets/images/items/soybean.png",
+      "bitmaskBit": 3
+    },
+    {
+      "key": "strawberry",
+      "spriteUrl": "/assets/images/items/strawberry.png",
+      "bitmaskBit": 11
     }
   ]
 }

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -19,8 +19,18 @@
     },
     {
       "key": "candy",
-      "spriteUrl": "/assets/images/items/candy.png",
-      "bitmaskBit": 0
+      "spriteUrl": "/assets/images/items/candy.png"
+    },
+    {
+      "key": "coconut",
+      "spriteUrl": "/assets/images/items/coconut.png",
+      "bitmaskBit": 9
+    },
+    {
+      "key": "strawberry",
+      "spriteUrl": "/assets/images/items/strawberry.png",
+      "bitmaskBit": 11,
+      "bonus": 20
     }
   ]
 }

--- a/src/phases/praia.json
+++ b/src/phases/praia.json
@@ -7,28 +7,43 @@
   "duration": 90,
   "items": [
     {
-      "allergens": [
-        "shellfish"
-      ],
+      "allergens": ["shellfish"],
       "key": "shrimp",
       "spriteUrl": "/assets/images/items/shrimp.png",
       "bitmaskBit": 6
     },
     {
-      "allergens": [],
-      "key": "coconut",
-      "spriteUrl": "/assets/images/items/coconut.png",
-      "bitmaskBit": 0
+      "allergens": ["fish"],
+      "key": "fish",
+      "spriteUrl": "/assets/images/items/fish.png",
+      "bitmaskBit": 5
     },
     {
-      "allergens": [
-        "gluten",
-        "egg",
-        "milk"
-      ],
+      "allergens": ["shellfish"],
+      "key": "squid",
+      "spriteUrl": "/assets/images/items/squid.png",
+      "bitmaskBit": 6,
+      "trap": true,
+      "penalty": 5
+    },
+    {
+      "allergens": ["coconut"],
+      "key": "coconut",
+      "spriteUrl": "/assets/images/items/coconut.png",
+      "bitmaskBit": 9
+    },
+    {
+      "allergens": ["gluten", "egg", "milk"],
       "key": "cake",
       "spriteUrl": "/assets/images/items/cake.png",
       "bitmaskBit": 1
+    },
+    {
+      "allergens": ["pineapple"],
+      "key": "pineapple",
+      "spriteUrl": "/assets/images/items/pineapple.png",
+      "bitmaskBit": 10,
+      "bonus": 15
     }
   ],
   "tips": [

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -16,12 +16,29 @@
       "key": "bread",
       "spriteUrl": "/assets/images/items/bread.png",
       "bitmaskBit": 4,
-      "trap": true
+      "trap": true,
+      "penalty": 10
     },
     {
       "key": "cereal",
       "spriteUrl": "/assets/images/items/cereal.png",
-      "bitmaskBit": 4
+      "bitmaskBit": 8
+    },
+    {
+      "key": "cheese",
+      "spriteUrl": "/assets/images/items/cheese.png",
+      "bitmaskBit": 0
+    },
+    {
+      "key": "egg",
+      "spriteUrl": "/assets/images/items/egg.png",
+      "bitmaskBit": 1
+    },
+    {
+      "key": "pineapple",
+      "spriteUrl": "/assets/images/items/pineapple.png",
+      "bitmaskBit": 10,
+      "bonus": 15
     }
   ]
 }


### PR DESCRIPTION
## Summary
- expand registration to include Coco, Abacaxi and Morango allergens
- add trap/bonus mechanics and distribute new items across phases
- handle trap penalties and bonuses in game engine

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_6890ace8990c832fb65f483a65400a7a