### PR TITLE
Scale background image to canvas size

### DIFF
--- a/src/gameEngine.js
+++ b/src/gameEngine.js
@@ -70,10 +70,11 @@ export default class PhaserGameEngine {
       create() {
         const { width, height } = this.scale;
         if (phaseConfig.background) {
-          this.add
-            .image(0, 0, 'background')
-            .setOrigin(0)
-            .setDisplaySize(width, height);
+          const bg = this.add.image(width / 2, height / 2, 'background');
+          const scaleX = width / bg.width;
+          const scaleY = height / bg.height;
+          const scale = Math.max(scaleX, scaleY);
+          bg.setScale(scale).setScrollFactor(0);
         }
         this.bgMusic = this.sound.add('bgMusic', { loop: true });
         this.bgMusic.play();


### PR DESCRIPTION
## Summary
- scale background sprite to cover canvas while maintaining aspect ratio

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6890c871fb60832f8bf7894b006aff07