### PR TITLE
Scale chef sprite relative to viewport

### DIFF
--- a/src/gameEngine.js
+++ b/src/gameEngine.js
@@ -69,6 +69,7 @@ export default class PhaserGameEngine {
       }
       create() {
         const { width, height } = this.scale;
+        const chefSize = width * 0.15;
         if (phaseConfig.background) {
           this.add
             .image(0, 0, 'background')
@@ -142,7 +143,8 @@ export default class PhaserGameEngine {
         // Chef sprite (ANIMAÇÃO)
         this.chef = this.add
           .sprite(width / 2, height - 100, 'chefIdle')
-          .setDepth(5);
+          .setDepth(5)
+          .setDisplaySize(chefSize, chefSize);
         this.tipTimer = null;
         // Pause
         const pauseButton = this.add


### PR DESCRIPTION
## Summary
- compute target size from viewport width for chef sprite
- apply display size to chef sprite to maintain consistent proportions

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_6890c8bbd598832fad2ed6086c76b801