### PR TITLE
feat: scale items proportionally

### DIFF
--- a/src/gameEngine.js
+++ b/src/gameEngine.js
@@ -182,8 +182,11 @@ export default class PhaserGameEngine {
       spawnItem() {
         const { width } = this.scale;
         const item = Phaser.Utils.Array.GetRandom(phaseConfig.items);
-        const x = Phaser.Math.Between(32, width - 32);
-        const sprite = this.physics.add.image(x, -32, item.key);
+        const sizeRatio = phaseConfig.itemScale || 0.1;
+        const itemSize = phaseConfig.itemSize || width * sizeRatio;
+        const x = Phaser.Math.Between(itemSize / 2, width - itemSize / 2);
+        const sprite = this.physics.add.image(x, -itemSize / 2, item.key);
+        sprite.setDisplaySize(itemSize, itemSize);
         sprite.setData('itemData', item);
         sprite.setVelocityY(100 * this.speed);
         sprite.setInteractive();

--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -2,6 +2,7 @@
   "background": "/assets/images/bg/feira_day.png",
   "spawnRate": 1500,
   "simultaneous": 2,
+  "itemScale": 0.09,
   "items": [
     {
       "key": "apple",

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -2,6 +2,7 @@
   "background": "/assets/images/bg/festa.png",
   "spawnRate": 1000,
   "simultaneous": 3,
+  "itemScale": 0.1,
   "items": [
     {
       "key": "cake",

--- a/src/phases/praia.json
+++ b/src/phases/praia.json
@@ -5,6 +5,7 @@
   "speed": 1.2,
   "itemSpawnRate": 800,
   "duration": 90,
+  "itemScale": 0.08,
   "items": [
     {
       "allergens": ["shellfish"],

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -2,6 +2,7 @@
   "background": "/assets/images/bg/supermercado.png",
   "spawnRate": 1400,
   "simultaneous": 3,
+  "itemScale": 0.09,
   "items": [
     {
       "key": "cookie",


### PR DESCRIPTION
## Summary
- size falling items relative to canvas width
- allow per-phase `itemScale` configuration

## Testing
- `CI=true npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_6890c90ffcbc832f8cfa5b083e8b9db4