### PR TITLE
feat: add responsive scaling to Phaser

### DIFF
--- a/src/gameEngine.js
+++ b/src/gameEngine.js
@@ -342,13 +342,26 @@ export default class PhaserGameEngine {
         default: 'arcade',
         arcade: { gravity: { y: 0 }, debug: false },
       },
+      scale: {
+        mode: Phaser.Scale.FIT,
+        autoCenter: Phaser.Scale.CENTER_BOTH,
+      },
     });
+
+    this.resizeHandler = () => {
+      this.game.scale.resize(window.innerWidth, window.innerHeight);
+    };
+    window.addEventListener('resize', this.resizeHandler);
   }
   destroy() {
     if (this.game) {
       this.bgMusic?.stop();
       this.game.destroy(true);
       this.game = null;
+    }
+    if (this.resizeHandler) {
+      window.removeEventListener('resize', this.resizeHandler);
+      this.resizeHandler = null;
     }
   }
 }


### PR DESCRIPTION
## Summary
- configure Phaser scaling to FIT and auto-center
- respond to window resizes by updating canvas size

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6890c936ad4c832fa3fe4a60ce1dafbd