### PR TITLE
feat: add transition screen for game flow

### DIFF
--- a/src/components/LoadingScreen.js
+++ b/src/components/LoadingScreen.js
@@ -1,24 +1,12 @@
 import React from 'react';
+import TransitionScreen from './TransitionScreen';
 
 /**
  * LoadingScreen
  *
- * Displayed while game assets such as the phase configuration or
- * player profile bitmask are being loaded.  Keeps the user informed
- * that something is happening instead of rendering nothing.
+ * Simple wrapper around TransitionScreen with a default loading message.
+ * Useful for async phases like asset or profile loading.
  */
-export default function LoadingScreen() {
-  return (
-    <div
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        justifyContent: 'center',
-        height: '100%',
-        fontSize: '1.5rem',
-      }}
-    >
-      Carregando...
-    </div>
-  );
+export default function LoadingScreen({ message = 'Carregando...' }) {
+  return <TransitionScreen message={message} />;
 }

--- a/src/components/MemoryGame.js
+++ b/src/components/MemoryGame.js
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import GameWrapper from './GameWrapper';
 import LoadingScreen from './LoadingScreen';
+import TransitionScreen from './TransitionScreen';
 import { useStore } from '../store';
 import { loadProfile } from '../services/firestore';
 import { loadNfcPreference } from '../utils/storage';
@@ -16,6 +17,7 @@ export default function MemoryGame() {
   const { phase } = useParams();
   const navigate = useNavigate();
   const [phaseConfig, setPhaseConfigState] = useState(null);
+  const [transitionMsg, setTransitionMsg] = useState('');
 
   // Zustand store
   const profile         = useStore((s) => s.profile);
@@ -70,20 +72,25 @@ export default function MemoryGame() {
     }
   }, [profile, setProfile]);
 
-  const handleReturnToMenu = () => {
-    navigate('/modes');
-  };
-  const handleGameOver = () => {
-    handleReturnToMenu();
+  const navigateWithTransition = (msg) => {
+    setTransitionMsg(msg);
+    setTimeout(() => navigate('/modes'), 800);
   };
 
+  const handleReturnToMenu = () => navigateWithTransition('Voltando ao menu...');
+  const handleGameOver = () => navigateWithTransition('Fim de jogo!');
+
   if (!phaseConfig || !profile) return <LoadingScreen />;
+
   return (
-    <GameWrapper
-      phaseConfig={phaseConfig}
-      bitmask={profile.bitmask || 0}
-      onGameOver={handleGameOver}
-      onReturnToMenu={handleReturnToMenu}
-    />
+    <>
+      <GameWrapper
+        phaseConfig={phaseConfig}
+        bitmask={profile.bitmask || 0}
+        onGameOver={handleGameOver}
+        onReturnToMenu={handleReturnToMenu}
+      />
+      {transitionMsg && <TransitionScreen message={transitionMsg} />}
+    </>
   );
 }

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -2,6 +2,7 @@ import React, { useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { loadProfile } from '../services/firestore';
 import { useStore } from '../store';
+import LoadingScreen from './LoadingScreen';
 
 // Lookup table for allergen names corresponding to each bit.
 const ALLERGEN_NAMES = [
@@ -37,7 +38,7 @@ export default function Profile() {
   }, [profile, setProfile]);
 
   if (!profile) {
-    return <div style={{ padding: '2rem' }}>Carregando…</div>;
+    return <LoadingScreen />;
   }
 
   // Compute a list of allergens from the bitmask for display.

--- a/src/components/StartupRedirect.js
+++ b/src/components/StartupRedirect.js
@@ -3,6 +3,7 @@ import { useNavigate } from 'react-router-dom';
 import { loadProfile } from '../services/firestore';
 import { loadNfcPreference } from '../utils/storage';
 import { useStore } from '../store';
+import LoadingScreen from './LoadingScreen';
 
 /**
  * Component that checks for an existing profile on load and
@@ -40,5 +41,5 @@ export default function StartupRedirect() {
     })();
   }, [navigate, setProfile]);
 
-  return <div style={{ padding: '2rem' }}>Carregando…</div>;
+  return <LoadingScreen />;
 }

--- a/src/components/TransitionScreen.js
+++ b/src/components/TransitionScreen.js
@@ -1,0 +1,48 @@
+import React, { useEffect, useState } from 'react';
+
+/**
+ * TransitionScreen
+ *
+ * A full-screen overlay used to present messages between major app
+ * transitions. Accepts children or a simple message string. Optionally
+ * fades in/out when the `show` prop changes.
+ */
+export default function TransitionScreen({
+  children,
+  message,
+  show = true,
+  fade = true,
+  duration = 500,
+  onComplete,
+}) {
+  const [visible, setVisible] = useState(show);
+  const [anim, setAnim] = useState(show ? 'fade-in' : 'fade-out');
+
+  useEffect(() => {
+    if (show) {
+      setVisible(true);
+      setAnim('fade-in');
+    } else if (fade) {
+      setAnim('fade-out');
+      const t = setTimeout(() => {
+        setVisible(false);
+        onComplete?.();
+      }, duration);
+      return () => clearTimeout(t);
+    } else {
+      setVisible(false);
+      onComplete?.();
+    }
+  }, [show, fade, duration, onComplete]);
+
+  if (!visible) return null;
+
+  return (
+    <div
+      className={`transition-screen ${fade ? anim : ''}`}
+      style={fade ? { animationDuration: `${duration}ms` } : null}
+    >
+      {children || <div>{message}</div>}
+    </div>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -47,3 +47,35 @@ body {
   object-fit: contain;
   margin-bottom: 0.5rem;
 }
+/* Transition screen overlay */
+.transition-screen {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: #fff;
+  z-index: 1000;
+  animation-fill-mode: forwards;
+}
+
+.transition-screen.fade-in {
+  animation-name: fadeIn;
+}
+
+.transition-screen.fade-out {
+  animation-name: fadeOut;
+}
+
+@keyframes fadeIn {
+  from { opacity: 0; }
+  to { opacity: 1; }
+}
+
+@keyframes fadeOut {
+  from { opacity: 1; }
+  to { opacity: 0; }
+}


### PR DESCRIPTION
## Summary
- add TransitionScreen overlay with optional fade animations
- use TransitionScreen for loading and navigation flows
- show transition after game over before returning to menu

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6890c9580bec832face3d9b8b13abd22