### PR TITLE
Add phase transition screens for sequential phases

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -7,6 +7,7 @@ import Tutorial from './components/Tutorial';
 import MemoryGame from './components/MemoryGame';
 import Intro from './components/Intro';
 import StartupRedirect from './components/StartupRedirect';
+import PhaseTransition from './components/PhaseTransition';
 
 /**
  * The top level application component.  It defines the routes
@@ -26,6 +27,7 @@ export default function App() {
       <Route path="/modes" element={<ModeSelect />} />
       <Route path="/tutorial" element={<Tutorial />} />
       <Route path="/play/:phase" element={<MemoryGame />} />
+      <Route path="/transition/:phase" element={<PhaseTransition />} />
       <Route path="*" element={<div style={{ padding: '1rem' }}>Page not found</div>} />
     </Routes>
   );

--- a/src/components/MemoryGame.js
+++ b/src/components/MemoryGame.js
@@ -26,6 +26,9 @@ export default function MemoryGame() {
   const cachedPhaseConfig = useStore((s) => s.phases[phase]);
   const setPhaseConfig  = useStore((s) => s.setPhaseConfig);
 
+  // Ordem das fases para permitir navegação sequencial
+  const PHASE_SEQUENCE = ['feira', 'supermercado', 'festa', 'praia'];
+
   // Carrega a configuração da fase, cacheando no Zustand
   useEffect(() => {
     (async () => {
@@ -78,7 +81,17 @@ export default function MemoryGame() {
   };
 
   const handleReturnToMenu = () => navigateWithTransition('Voltando ao menu...');
-  const handleGameOver = () => navigateWithTransition('Fim de jogo!');
+
+  // Após o término de uma fase, direciona para a tela de transição
+  const handlePhaseComplete = () => {
+    const currentIndex = PHASE_SEQUENCE.indexOf(phase);
+    const nextPhase = PHASE_SEQUENCE[currentIndex + 1];
+    if (nextPhase) {
+      navigate(`/transition/${nextPhase}`);
+    } else {
+      navigateWithTransition('Fim de jogo!');
+    }
+  };
 
   if (!phaseConfig || !profile) return <LoadingScreen />;
 
@@ -87,7 +100,7 @@ export default function MemoryGame() {
       <GameWrapper
         phaseConfig={phaseConfig}
         bitmask={profile.bitmask || 0}
-        onGameOver={handleGameOver}
+        onGameOver={handlePhaseComplete}
         onReturnToMenu={handleReturnToMenu}
       />
       {transitionMsg && <TransitionScreen message={transitionMsg} />}

--- a/src/components/PhaseTransition.js
+++ b/src/components/PhaseTransition.js
@@ -1,0 +1,56 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import TransitionScreen from './TransitionScreen';
+
+/**
+ * PhaseTransition
+ *
+ * Displays a message and optional image between phases before the next
+ * phase of the game begins. It pulls the configuration from the target
+ * phase JSON and then navigates to the MemoryGame route for that phase
+ * after a short delay.
+ */
+export default function PhaseTransition() {
+  const { phase } = useParams();
+  const navigate = useNavigate();
+  const [config, setConfig] = useState(null);
+
+  useEffect(() => {
+    (async () => {
+      try {
+        const imported = await import(`../phases/${phase}.json`);
+        setConfig(imported.default || imported);
+      } catch (err) {
+        console.error('Erro ao carregar fase', err);
+        navigate('/modes');
+      }
+    })();
+  }, [phase, navigate]);
+
+  useEffect(() => {
+    if (config) {
+      const t = setTimeout(() => navigate(`/play/${phase}`), 800);
+      return () => clearTimeout(t);
+    }
+  }, [config, navigate, phase]);
+
+  if (!config) return null;
+
+  const transition = config.transition || {};
+  const { text, image } = transition;
+
+  return (
+    <TransitionScreen>
+      <div className="phase-transition" style={{ textAlign: 'center' }}>
+        {image && (
+          <img
+            src={image}
+            alt=""
+            style={{ maxWidth: '80%', marginBottom: '1rem' }}
+          />
+        )}
+        {text && <h2>{text}</h2>}
+      </div>
+    </TransitionScreen>
+  );
+}

--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -1,4 +1,8 @@
 {
+  "transition": {
+    "text": "Bem-vindo à Feira!",
+    "image": "/assets/images/bg/feira_day.png"
+  },
   "background": "/assets/images/bg/feira_day.png",
   "spawnRate": 1500,
   "simultaneous": 2,

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -1,4 +1,8 @@
 {
+  "transition": {
+    "text": "Festa de Aniversário chegando!",
+    "image": "/assets/images/bg/festa.png"
+  },
   "background": "/assets/images/bg/festa.png",
   "spawnRate": 1000,
   "simultaneous": 3,

--- a/src/phases/praia.json
+++ b/src/phases/praia.json
@@ -1,5 +1,9 @@
 {
   "phaseId": "praia",
+  "transition": {
+    "text": "Vamos relaxar na Praia!",
+    "image": "/assets/images/bg/praia.png"
+  },
   "background": "/assets/images/bg/praia.png",
   "music": "/assets/audio/beach_loop.mp3",
   "speed": 1.2,

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -1,4 +1,8 @@
 {
+  "transition": {
+    "text": "Hora das compras no Supermercado!",
+    "image": "/assets/images/bg/supermercado.png"
+  },
   "background": "/assets/images/bg/supermercado.png",
   "spawnRate": 1400,
   "simultaneous": 3,


### PR DESCRIPTION
## Summary
- create PhaseTransition screen leveraging TransitionScreen to show per-phase intro and auto-start game
- load next phase via PhaseTransition in MemoryGame for sequential progression
- store transition text and images in each phase config and add route

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6890e0d66460832fa1d924557e4df523