### PR TITLE
refactor: centralize allergen names list

### DIFF
--- a/src/components/EditProfile.js
+++ b/src/components/EditProfile.js
@@ -4,22 +4,9 @@ import { saveProfile } from '../services/firestore';
 import { saveNfcPreference } from '../utils/storage';
 import { arrayToBitmask, bitmaskToArray } from '../utils/bitmask';
 import { useStore } from '../store';
+import { ALLERGEN_NAMES } from '../constants/allergens';
 
-// Lista de alérgenos. A ordem deve ser igual à de ALLERGEN_NAMES em Profile.js.
-const ALLERGEN_NAMES = [
-  'Leite',
-  'Ovo',
-  'Amendoim',
-  'Soja',
-  'Trigo',
-  'Peixes',
-  'Frutos do Mar',
-  'Castanhas',
-  'Milho',
-  'Coco',
-  'Abacaxi',
-  'Morango',
-];
+// Lista de alérgenos importada de src/constants/allergens.js. A ordem deve ser mantida.
 
 export default function EditProfile() {
   const navigate = useNavigate();

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -3,22 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { loadProfile } from '../services/firestore';
 import { useStore } from '../store';
 import LoadingScreen from './LoadingScreen';
+import { ALLERGEN_NAMES } from '../constants/allergens';
 
 // Lookup table for allergen names corresponding to each bit.
-const ALLERGEN_NAMES = [
-  'Leite',
-  'Ovo',
-  'Amendoim',
-  'Soja',
-  'Trigo',
-  'Peixes',
-  'Frutos do Mar',
-  'Castanhas',
-  'Milho',
-  'Coco',
-  'Abacaxi',
-  'Morango'
-];
 
 /**
  * Displays the saved user profile along with a list of allergens to avoid.

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -3,22 +3,9 @@ import { useNavigate } from 'react-router-dom';
 import { saveProfile } from '../services/firestore';
 import { saveNfcPreference } from '../utils/storage';
 import { arrayToBitmask } from '../utils/bitmask';
+import { ALLERGEN_NAMES } from '../constants/allergens';
 
-// Lista de alérgenos. A ordem deve ser igual à de ALLERGEN_NAMES em Profile.js.
-const ALLERGEN_NAMES = [
-  'Leite',
-  'Ovo',
-  'Amendoim',
-  'Soja',
-  'Trigo',
-  'Peixes',
-  'Frutos do Mar',
-  'Castanhas',
-  'Milho',
-  'Coco',
-  'Abacaxi',
-  'Morango',
-];
+// Lista de alérgenos importada de src/constants/allergens.js. A ordem deve ser mantida.
 
 // Gera um UID simples combinando timestamp e número aleatório.
 const generateUid = () => {

--- a/src/constants/allergens.js
+++ b/src/constants/allergens.js
@@ -1,0 +1,15 @@
+// Lista de alérgenos. A ordem corresponde aos bits armazenados no perfil.
+export const ALLERGEN_NAMES = [
+  'Leite',
+  'Ovo',
+  'Amendoim',
+  'Soja',
+  'Trigo',
+  'Peixes',
+  'Frutos do Mar',
+  'Castanhas',
+  'Milho',
+  'Coco',
+  'Abacaxi',
+  'Morango',
+];


### PR DESCRIPTION
## Summary
- centralize allergen names in `src/constants/allergens.js`
- replace duplicated allergen arrays with shared constant
- update comments referencing allergen array location

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890ec062bf8832fbd87d2fef310ff70