### PR TITLE
Add DifficultyManager unit tests for accuracy and scaling

### DIFF
--- a/src/utils/DifficultyManager.test.js
+++ b/src/utils/DifficultyManager.test.js
@@ -1,0 +1,32 @@
+import DifficultyManager from './DifficultyManager';
+
+describe('DifficultyManager', () => {
+  test('calculates accuracy across event sequences', () => {
+    const dm = new DifficultyManager(3);
+    expect(dm.getAccuracy()).toBe(1);
+    dm.record(true);
+    expect(dm.getAccuracy()).toBe(1);
+    dm.record(false);
+    expect(dm.getAccuracy()).toBeCloseTo(0.5);
+    dm.record(false);
+    expect(dm.getAccuracy()).toBeCloseTo(1/3);
+    dm.record(false);
+    expect(dm.getAccuracy()).toBe(0);
+  });
+
+  test('parameters scale with accuracy bounds', () => {
+    const dmLow = new DifficultyManager();
+    for (let i = 0; i < dmLow.windowSize; i++) dmLow.record(false);
+    const low = dmLow.getParameters();
+
+    const dmHigh = new DifficultyManager();
+    for (let i = 0; i < dmHigh.windowSize; i++) dmHigh.record(true);
+    const high = dmHigh.getParameters();
+
+    expect(low.spawnRate).toBeGreaterThan(high.spawnRate);
+    expect(low.simultaneous).toBeLessThan(high.simultaneous);
+    expect(low).toEqual({ spawnRate: 3000, simultaneous: 1 });
+    expect(high).toEqual({ spawnRate: 1000, simultaneous: 3 });
+  });
+});
+


### PR DESCRIPTION
## Summary
- add tests for DifficultyManager accuracy calculation through varied event sequences
- validate getParameters adjusts spawn rate and simultaneous items based on accuracy extremes

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_6890ec97bd7c832f8218b9847fbc3f3c