### PR TITLE
feat: add accessible navigation menu

### DIFF
--- a/src/components/CareerMap.js
+++ b/src/components/CareerMap.js
@@ -2,6 +2,7 @@ import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import FadeIn from './FadeIn';
 import { useStore } from '../store';
+import NavBar from './NavBar';
 
 // Thumbnails for each phase
 // Assets are served from the public folder using absolute paths
@@ -25,6 +26,7 @@ export default function CareerMap() {
 
   return (
     <FadeIn>
+      <NavBar />
       <div
         style={{
           backgroundImage: 'url(/assets/images/ui/mode_select_bg.jpg)',

--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { useNavigate } from 'react-router-dom';
 import FadeIn from './FadeIn';
+import NavBar from './NavBar';
 
 /**
  * Tela inicial que apresenta rapidamente a premissa do jogo.
@@ -10,6 +11,7 @@ export default function Intro() {
   const handleStart = () => navigate('/startup');
   return (
     <FadeIn>
+      <NavBar />
       <div
         style={{
           backgroundImage: 'url(/assets/images/ui/intro_bg.jpg)',

--- a/src/components/MemoryGame.js
+++ b/src/components/MemoryGame.js
@@ -7,6 +7,7 @@ import { useStore } from '../store';
 import { loadProfile } from '../services/firestore';
 import { loadNfcPreference } from '../utils/storage';
 import { PHASES } from './ModeSelect';
+import NavBar from './NavBar';
 
 /**
  * MemoryGame
@@ -103,6 +104,7 @@ export default function MemoryGame() {
 
   return (
     <>
+      <NavBar />
       <GameWrapper
         phaseConfig={phaseConfig}
         bitmask={profile.bitmask || 0}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,0 +1,31 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+/**
+ * Accessible navigation menu present on main screens.
+ */
+export default function NavBar() {
+  return (
+    <nav aria-label="Navegação principal">
+      <ul
+        style={{
+          display: 'flex',
+          gap: '1rem',
+          listStyle: 'none',
+          padding: 0,
+          margin: 0
+        }}
+      >
+        <li>
+          <Link to="/profile">Perfil</Link>
+        </li>
+        <li>
+          <Link to="/tutorial">Tutorial</Link>
+        </li>
+        <li>
+          <Link to="/modes">Mapa</Link>
+        </li>
+      </ul>
+    </nav>
+  );
+}

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -4,6 +4,7 @@ import { loadProfile } from '../services/firestore';
 import { useStore } from '../store';
 import LoadingScreen from './LoadingScreen';
 import { ALLERGEN_NAMES } from '../constants/allergens';
+import NavBar from './NavBar';
 
 // Lookup table for allergen names corresponding to each bit.
 
@@ -33,22 +34,25 @@ export default function Profile() {
   const selected = ALLERGEN_NAMES.slice(0, bitCount).filter((_, idx) => (profile.bitmask & (1 << idx)) !== 0);
 
   return (
-    <div style={{ padding: '2rem' }}>
-      <h1>Seu Perfil</h1>
-      <p>
-        <strong>Nome:</strong> {profile.nome}
-      </p>
-      <p>
-        <strong>Idade:</strong> {profile.idade}
-      </p>
-      <p>
-        <strong>Alérgenos selecionados:</strong>{' '}
-        {selected.length > 0 ? selected.join(', ') : 'Nenhum'}
-      </p>
-      <div style={{ display: 'flex', gap: '1rem' }}>
-        <button onClick={() => navigate('/modes')}>Selecionar Fase</button>
-        <button onClick={() => navigate('/profile/edit')}>Editar perfil</button>
+    <>
+      <NavBar />
+      <div style={{ padding: '2rem' }}>
+        <h1>Seu Perfil</h1>
+        <p>
+          <strong>Nome:</strong> {profile.nome}
+        </p>
+        <p>
+          <strong>Idade:</strong> {profile.idade}
+        </p>
+        <p>
+          <strong>Alérgenos selecionados:</strong>{' '}
+          {selected.length > 0 ? selected.join(', ') : 'Nenhum'}
+        </p>
+        <div style={{ display: 'flex', gap: '1rem' }}>
+          <button onClick={() => navigate('/modes')}>Selecionar Fase</button>
+          <button onClick={() => navigate('/profile/edit')}>Editar perfil</button>
+        </div>
       </div>
-    </div>
+    </>
   );
 }


### PR DESCRIPTION
## Summary
- add NavBar component linking to Perfil, Tutorial and Mapa
- show navigation bar on Intro, CareerMap, Profile and MemoryGame screens

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_689101f32900832f8bf205f6bd10bc6b