### PR TITLE
feat: style navbar with external stylesheet

### DIFF
--- a/src/components/NavBar.css
+++ b/src/components/NavBar.css
@@ -1,0 +1,12 @@
+.navbar {
+  background: linear-gradient(rgba(0, 0, 0, 0.4), rgba(0, 0, 0, 0.4)),
+    url('../assets/images/bg/festa.png') center/cover no-repeat;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  gap: 1rem;
+  list-style: none;
+  padding: 1rem;
+  margin: 0;
+  font-family: sans-serif;
+}

--- a/src/components/NavBar.js
+++ b/src/components/NavBar.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Link } from 'react-router-dom';
+import './NavBar.css';
 
 /**
  * Accessible navigation menu present on main screens.
@@ -7,15 +8,7 @@ import { Link } from 'react-router-dom';
 export default function NavBar() {
   return (
     <nav aria-label="Navegação principal">
-      <ul
-        style={{
-          display: 'flex',
-          gap: '1rem',
-          listStyle: 'none',
-          padding: 0,
-          margin: 0
-        }}
-      >
+      <ul className="navbar">
         <li>
           <Link to="/profile">Perfil</Link>
         </li>


### PR DESCRIPTION
## Summary
- add NavBar.css with background image, overlay and flex layout
- import stylesheet and apply `navbar` class instead of inline styles

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_689120011e50832f9964339e00c81078