### PR TITLE
Use parent bounds for game dimensions

### DIFF
--- a/src/gameEngine.js
+++ b/src/gameEngine.js
@@ -16,10 +16,12 @@ export default class PhaserGameEngine {
     if (this.game) return;
     const { phaseConfig, bitmask, onGameOver, onReturnToMenu } = this;
 
+    const { width, height } = parent.getBoundingClientRect();
+
     this.game = new Phaser.Game({
       type: Phaser.AUTO,
-      width: window.innerWidth,
-      height: window.innerHeight,
+      width,
+      height,
       parent,
       scene: [
         new GameScene({ phaseConfig, bitmask, onGameOver, engine: this }),
@@ -36,7 +38,8 @@ export default class PhaserGameEngine {
     });
 
     this.resizeHandler = () => {
-      this.game.scale.resize(window.innerWidth, window.innerHeight);
+      const { width: newWidth, height: newHeight } = parent.getBoundingClientRect();
+      this.game.scale.resize(newWidth, newHeight);
     };
     window.addEventListener('resize', this.resizeHandler);
   }


### PR DESCRIPTION
## Summary
- derive Phaser game size from parent element bounds
- update resize handler to recalc size from container

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68912d7f4270832f802f78e6bbc8fd3c