### PR TITLE
Add phase metadata and defaults

### DIFF
--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -9,7 +9,10 @@
     "animation": "slide"
   },
   "background": "/assets/images/bg/feira_day.png",
-  "spawnRate": 1500,
+  "music": "/assets/audio/background.ogg",
+  "speed": 1,
+  "itemSpawnRate": 1500,
+  "duration": 60,
   "simultaneous": 2,
   "itemScale": 0.09,
   "items": [
@@ -43,5 +46,9 @@
       "spriteUrl": "/assets/images/items/strawberry.png",
       "bitmaskBit": 11
     }
+  ],
+  "tips": [
+    "Amendoim e soja são alergênicos comuns na feira.",
+    "Fique de olho em castanhas escondidas em doces."
   ]
 }

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -4,7 +4,10 @@
     "image": "/assets/images/bg/festa.png"
   },
   "background": "/assets/images/bg/festa.png",
-  "spawnRate": 1000,
+  "music": "/assets/audio/background.ogg",
+  "speed": 1.3,
+  "itemSpawnRate": 1000,
+  "duration": 80,
   "simultaneous": 3,
   "itemScale": 0.1,
   "items": [
@@ -38,5 +41,9 @@
       "bitmaskBit": 11,
       "bonus": 20
     }
+  ],
+  "tips": [
+    "Bolos e sorvetes quase sempre contêm leite e ovos.",
+    "Doces coloridos podem ter traços de amendoim."
   ]
 }

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -4,7 +4,10 @@
     "image": "/assets/images/bg/supermercado.png"
   },
   "background": "/assets/images/bg/supermercado.png",
-  "spawnRate": 1400,
+  "music": "/assets/audio/background.ogg",
+  "speed": 1.1,
+  "itemSpawnRate": 1400,
+  "duration": 70,
   "simultaneous": 3,
   "itemScale": 0.09,
   "items": [
@@ -46,5 +49,9 @@
       "bitmaskBit": 10,
       "bonus": 15
     }
+  ],
+  "tips": [
+    "Leia os rótulos para evitar glúten e lactose.",
+    "Produtos industrializados podem esconder alergênicos."
   ]
 }

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -26,6 +26,7 @@ export default class GameScene extends Phaser.Scene {
     this.speed = phaseConfig.speed || 1;
     this.duration = phaseConfig.duration || null;
     this.tips = phaseConfig.tips || [];
+    this.music = phaseConfig.music || '/assets/audio/background.ogg';
     this.tipText = null;
     this.tipCard = null;
     this.lifeIcons = [];
@@ -52,8 +53,7 @@ export default class GameScene extends Phaser.Scene {
     if (phaseConfig.background) {
       this.load.image('background', phaseConfig.background);
     }
-    const music = phaseConfig.music || '/assets/audio/background.ogg';
-    this.load.audio('bgMusic', music);
+    this.load.audio('bgMusic', this.music);
     this.load.audio('safeSound', '/assets/audio/safe.ogg');
     this.load.audio('allergenSound', '/assets/audio/allergen.ogg');
   }


### PR DESCRIPTION
## Summary
- add music, speed, itemSpawnRate, duration and tips to Feira, Festa and Supermercado phase configs
- load background music from config with default fallback

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_689139fa45cc832fafe6155bce32d7d8