### PR TITLE
refactor: make HUD responsive with animations

### DIFF
--- a/src/utils/hudConfig.js
+++ b/src/utils/hudConfig.js
@@ -1,0 +1,14 @@
+export const getHUDConfig = (width, height) => {
+  const margin = width * 0.02;
+  const iconSize = width * 0.04;
+  return {
+    margin,
+    iconSize,
+    textStyle: { fontSize: `${iconSize}px`, fill: '#fff' },
+    tip: {
+      cardWidth: width * 0.375,
+      cardHeight: height * 0.166,
+      y: height - height * 0.166 - margin,
+    },
+  };
+};


### PR DESCRIPTION
## Summary
- group score, lives and timer into a responsive HUD container
- centralize HUD sizing logic
- animate HUD updates using tweens

## Testing
- `node -e "import('./src/utils/hudConfig.js').then(m=>{console.log('800x600', m.getHUDConfig(800,600)); console.log('1200x900', m.getHUDConfig(1200,900));})"`
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_68913a4ea5e8832fbe0bb891c02f52f6