### PR TITLE
Refactor intro screen layout

### DIFF
--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -9,31 +9,21 @@ import NavBar from './NavBar';
 export default function Intro() {
   const navigate = useNavigate();
   const handleStart = () => navigate('/startup');
+  const handleSkip = () => navigate('/modes');
   return (
     <FadeIn>
       <NavBar />
-      <div
-        style={{
-          backgroundImage: 'url(/assets/images/ui/intro_bg.jpg)',
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-          minHeight: '100vh',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center',
-          justifyContent: 'center',
-          textAlign: 'center',
-          padding: '2rem'
-        }}
-      >
-        <h1>Chef Alerg</h1>
-        <p>
-          Você é o Chef Alerg, um detetive de alergias viajando pelo mundo
-          para proteger pessoas de ingredientes perigosos. Descubra o que é seguro
-          em cada fase e ajude a todos a comer sem medo!
-        </p>
-        <button onClick={handleStart}>Iniciar Missão</button>
-        <button onClick={handleStart}>Pular</button>
+      <div className="intro-screen">
+        <div className="intro-content">
+          <h1>Chef Alerg</h1>
+          <p>
+            Você é o Chef Alerg, um detetive de alergias viajando pelo mundo
+            para proteger pessoas de ingredientes perigosos. Descubra o que é seguro
+            em cada fase e ajude a todos a comer sem medo!
+          </p>
+          <button onClick={handleStart}>Iniciar Missão</button>
+          <button onClick={handleSkip}>Pular</button>
+        </div>
       </div>
     </FadeIn>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -128,6 +128,13 @@ body {
   padding: 2rem;
 }
 
+.intro-content {
+  max-width: 600px;
+  width: 100%;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.8);
+}
+
 .not-found {
   padding: 1rem;
 }


### PR DESCRIPTION
## Summary
- use existing CSS class for intro background instead of inline styles
- wrap intro text and buttons in `.intro-content` with translucent background
- give "Pular" button distinct navigation to mode selection

## Testing
- `npm test --silent -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68913a621058832fa5d24613ca9babf7