### PR TITLE
Add reusable page content container and apply to forms

### DIFF
--- a/src/components/EditProfile.js
+++ b/src/components/EditProfile.js
@@ -65,62 +65,64 @@ export default function EditProfile() {
 
   return (
     <PageLayout>
-      <h1>Editar Perfil</h1>
-      <form onSubmit={handleSubmit}>
-        <div className="form-group">
-          <label>
-            Nome:
-            <input
-              type="text"
-              value={nome}
-              onChange={(e) => setNome(e.target.value)}
-              required
-            />
-          </label>
-        </div>
-        <div className="form-group">
-          <label>
-            Idade:
-            <input
-              type="number"
-              min="0"
-              value={idade}
-              onChange={(e) => setIdade(e.target.value)}
-              required
-            />
-          </label>
-        </div>
-        <div className="form-group">
-          <strong>Selecione seus alérgenos:</strong>
-          <ul className="list-unstyled">
-            {ALLERGEN_NAMES.map((name, idx) => (
-              <li key={idx}>
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={selectedBits.includes(idx)}
-                    onChange={() => toggleAlergeno(idx)}
-                  />
-                  {name}
-                </label>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div className="form-group">
-          <label>
-            <input
-              type="checkbox"
-              checked={useNfc}
-              onChange={(e) => setUseNfc(e.target.checked)}
-            />
-            Usar NFC para armazenar o perfil
-          </label>
-        </div>
-        <button type="submit" disabled={saving}>
-          {saving ? 'Salvando…' : 'Salvar Perfil'}
-        </button>
-      </form>
+      <div className="page-content">
+        <h1>Editar Perfil</h1>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label>
+              Nome:
+              <input
+                type="text"
+                value={nome}
+                onChange={(e) => setNome(e.target.value)}
+                required
+              />
+            </label>
+          </div>
+          <div className="form-group">
+            <label>
+              Idade:
+              <input
+                type="number"
+                min="0"
+                value={idade}
+                onChange={(e) => setIdade(e.target.value)}
+                required
+              />
+            </label>
+          </div>
+          <div className="form-group">
+            <strong>Selecione seus alérgenos:</strong>
+            <ul className="list-unstyled">
+              {ALLERGEN_NAMES.map((name, idx) => (
+                <li key={idx}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={selectedBits.includes(idx)}
+                      onChange={() => toggleAlergeno(idx)}
+                    />
+                    {name}
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="form-group">
+            <label>
+              <input
+                type="checkbox"
+                checked={useNfc}
+                onChange={(e) => setUseNfc(e.target.checked)}
+              />
+              Usar NFC para armazenar o perfil
+            </label>
+          </div>
+          <button type="submit" disabled={saving}>
+            {saving ? 'Salvando…' : 'Salvar Perfil'}
+          </button>
+        </form>
+      </div>
     </PageLayout>
   );
 }

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -36,20 +36,22 @@ export default function Profile() {
     <>
       <NavBar />
       <PageLayout>
-        <h1>Seu Perfil</h1>
-        <p>
-          <strong>Nome:</strong> {profile.nome}
-        </p>
-        <p>
-          <strong>Idade:</strong> {profile.idade}
-        </p>
-        <p>
-          <strong>Alérgenos selecionados:</strong>{' '}
-          {selected.length > 0 ? selected.join(', ') : 'Nenhum'}
-        </p>
-        <div style={{ display: 'flex', gap: '1rem' }}>
-          <button onClick={() => navigate('/modes')}>Selecionar Fase</button>
-          <button onClick={() => navigate('/profile/edit')}>Editar perfil</button>
+        <div className="page-content">
+          <h1>Seu Perfil</h1>
+          <p>
+            <strong>Nome:</strong> {profile.nome}
+          </p>
+          <p>
+            <strong>Idade:</strong> {profile.idade}
+          </p>
+          <p>
+            <strong>Alérgenos selecionados:</strong>{' '}
+            {selected.length > 0 ? selected.join(', ') : 'Nenhum'}
+          </p>
+          <div className="flex-gap">
+            <button onClick={() => navigate('/modes')}>Selecionar Fase</button>
+            <button onClick={() => navigate('/profile/edit')}>Editar perfil</button>
+          </div>
         </div>
       </PageLayout>
     </>

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -63,62 +63,64 @@ export default function RegisterForm() {
 
   return (
     <PageLayout>
-      <h1>Cadastro</h1>
-      <form onSubmit={handleSubmit}>
-        <div className="form-group">
-          <label>
-            Nome:
-            <input
-              type="text"
-              value={nome}
-              onChange={(e) => setNome(e.target.value)}
-              required
-            />
-          </label>
-        </div>
-        <div className="form-group">
-          <label>
-            Idade:
-            <input
-              type="number"
-              min="0"
-              value={idade}
-              onChange={(e) => setIdade(e.target.value)}
-              required
-            />
-          </label>
-        </div>
-        <div className="form-group">
-          <strong>Selecione seus alérgenos:</strong>
-          <ul className="list-unstyled">
-            {ALLERGEN_NAMES.map((name, idx) => (
-              <li key={idx}>
-                <label>
-                  <input
-                    type="checkbox"
-                    checked={selectedBits.includes(idx)}
-                    onChange={() => toggleAlergeno(idx)}
-                  />
-                  {name}
-                </label>
-              </li>
-            ))}
-          </ul>
-        </div>
-        <div className="form-group">
-          <label>
-            <input
-              type="checkbox"
-              checked={useNfc}
-              onChange={(e) => setUseNfc(e.target.checked)}
-            />
-            Usar NFC para armazenar o perfil
-          </label>
-        </div>
-        <button type="submit" disabled={saving}>
-          {saving ? 'Salvando…' : 'Salvar Perfil'}
-        </button>
-      </form>
+      <div className="page-content">
+        <h1>Cadastro</h1>
+        <form onSubmit={handleSubmit}>
+          <div className="form-group">
+            <label>
+              Nome:
+              <input
+                type="text"
+                value={nome}
+                onChange={(e) => setNome(e.target.value)}
+                required
+              />
+            </label>
+          </div>
+          <div className="form-group">
+            <label>
+              Idade:
+              <input
+                type="number"
+                min="0"
+                value={idade}
+                onChange={(e) => setIdade(e.target.value)}
+                required
+              />
+            </label>
+          </div>
+          <div className="form-group">
+            <strong>Selecione seus alérgenos:</strong>
+            <ul className="list-unstyled">
+              {ALLERGEN_NAMES.map((name, idx) => (
+                <li key={idx}>
+                  <label>
+                    <input
+                      type="checkbox"
+                      checked={selectedBits.includes(idx)}
+                      onChange={() => toggleAlergeno(idx)}
+                    />
+                    {name}
+                  </label>
+                </li>
+              ))}
+            </ul>
+          </div>
+          <div className="form-group">
+            <label>
+              <input
+                type="checkbox"
+                checked={useNfc}
+                onChange={(e) => setUseNfc(e.target.checked)}
+              />
+              Usar NFC para armazenar o perfil
+            </label>
+          </div>
+          <button type="submit" disabled={saving}>
+            {saving ? 'Salvando…' : 'Salvar Perfil'}
+          </button>
+        </form>
+      </div>
     </PageLayout>
   );
 }

--- a/src/components/Tutorial.js
+++ b/src/components/Tutorial.js
@@ -18,53 +18,55 @@ export default function Tutorial() {
   const navigate = useNavigate();
   return (
     <PageLayout>
-      <h1>Tutorial</h1>
-      <p>
-        Bem‑vindo ao Chef Alerg! O objetivo é arrastar ou tocar os
-        alimentos seguros para a panela enquanto evita os ingredientes
-        que contêm alérgenos. Cada fase possui um conjunto de
-        ingredientes e um nível de dificuldade diferente.
-      </p>
-      <p>
-        Toque nas frutas e legumes frescos e arraste-os até a panela.
-        Fique atento aos rótulos dos produtos no supermercado e
-        evite aqueles que contêm seus alérgenos. Se cometer um erro,
-        você perderá uma vida
-        <img
-          src={lifeIcon}
-          alt="Vidas"
-          className="inline-icon"
-        />
-        e receberá uma dica
-        <img
-          src={tipIcon}
-          alt="Dica"
-          className="inline-icon"
-        />
-        sobre o ingrediente.
-      </p>
-      <p>
-        Use o ícone
-        <img
-          src={pauseIcon}
-          alt="Pausar"
-          className="inline-icon"
-        />
-        para pausar o jogo. Acompanhe sua pontuação
-        <img
-          src={scoreIcon}
-          alt="Pontuação"
-          className="inline-icon"
-        />
-        e o tempo restante
-        <img
-          src={timeIcon}
-          alt="Tempo"
-          className="inline-icon"
-        />
-        na parte superior da tela.
-      </p>
-      <button onClick={() => navigate('/modes')}>Voltar</button>
+      <div className="page-content">
+        <h1>Tutorial</h1>
+        <p>
+          Bem‑vindo ao Chef Alerg! O objetivo é arrastar ou tocar os
+          alimentos seguros para a panela enquanto evita os ingredientes
+          que contêm alérgenos. Cada fase possui um conjunto de
+          ingredientes e um nível de dificuldade diferente.
+        </p>
+        <p>
+          Toque nas frutas e legumes frescos e arraste-os até a panela.
+          Fique atento aos rótulos dos produtos no supermercado e
+          evite aqueles que contêm seus alérgenos. Se cometer um erro,
+          você perderá uma vida
+          <img
+            src={lifeIcon}
+            alt="Vidas"
+            className="inline-icon"
+          />
+          e receberá uma dica
+          <img
+            src={tipIcon}
+            alt="Dica"
+            className="inline-icon"
+          />
+          sobre o ingrediente.
+        </p>
+        <p>
+          Use o ícone
+          <img
+            src={pauseIcon}
+            alt="Pausar"
+            className="inline-icon"
+          />
+          para pausar o jogo. Acompanhe sua pontuação
+          <img
+            src={scoreIcon}
+            alt="Pontuação"
+            className="inline-icon"
+          />
+          e o tempo restante
+          <img
+            src={timeIcon}
+            alt="Tempo"
+            className="inline-icon"
+          />
+          na parte superior da tela.
+        </p>
+        <button onClick={() => navigate('/modes')}>Voltar</button>
+      </div>
     </PageLayout>
   );
 }

--- a/src/index.css
+++ b/src/index.css
@@ -135,6 +135,13 @@ body {
   background: rgba(255, 255, 255, 0.8);
 }
 
+.page-content {
+  max-width: 600px;
+  width: 100%;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.8);
+}
+
 .not-found {
   padding: 1rem;
 }


### PR DESCRIPTION
## Summary
- add `.page-content` style for centered content blocks
- use new container in profile, edit profile, register, and tutorial screens
- replace inline button container with `flex-gap`

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_68914745f8c4832f9cd4abff2fc856fd