### PR TITLE
refactor: use css classes for career map

### DIFF
--- a/src/components/CareerMap.js
+++ b/src/components/CareerMap.js
@@ -24,35 +24,26 @@ export default function CareerMap() {
   return (
     <FadeIn>
       <NavBar />
-      <div
-        style={{
-          backgroundImage: 'url(/assets/images/ui/mode_select_bg.jpg)',
-          backgroundSize: 'cover',
-          backgroundPosition: 'center',
-          minHeight: '100vh',
-          padding: '2rem',
-          display: 'flex',
-          flexDirection: 'column',
-          alignItems: 'center'
-        }}
-      >
-        <h1>Mapa de Carreira</h1>
-        <div className="phase-grid">
-          {PHASES.map(({ key, label, img, alt }) => {
-            const unlocked = unlockedPhases.includes(key);
-            return (
-              <button
-                key={key}
-                className="phase-button"
-                onClick={() => unlocked && navigate(`/play/${key}`)}
-                aria-label={label}
-                disabled={!unlocked}
-              >
-                <img src={img} alt={alt || label} />
-                <span>{label}</span>
-              </button>
-            );
-          })}
+      <div className="career-map-screen">
+        <div className="page-content">
+          <h1>Mapa de Carreira</h1>
+          <div className="phase-grid">
+            {PHASES.map(({ key, label, img, alt }) => {
+              const unlocked = unlockedPhases.includes(key);
+              return (
+                <button
+                  key={key}
+                  className="phase-button"
+                  onClick={() => unlocked && navigate(`/play/${key}`)}
+                  aria-label={label}
+                  disabled={!unlocked}
+                >
+                  <img src={img} alt={alt || label} />
+                  <span>{label}</span>
+                </button>
+              );
+            })}
+          </div>
         </div>
       </div>
     </FadeIn>

--- a/src/index.css
+++ b/src/index.css
@@ -113,6 +113,17 @@ body {
   background-position: center;
   min-height: 100vh;
   padding: 2rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+}
+
+.page-content {
+  max-width: 600px;
+  width: 100%;
+  padding: 2rem;
+  background: rgba(255, 255, 255, 0.8);
 }
 
 .intro-screen {


### PR DESCRIPTION
## Summary
- replace inline style with `career-map-screen` class and inner `page-content` card
- move layout and background styles to `index.css`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_689147487e04832f8d55031c31602ccb