### PR TITLE
Add reusable button styling and apply across app

### DIFF
--- a/src/components/EditProfile.js
+++ b/src/components/EditProfile.js
@@ -118,7 +118,7 @@ export default function EditProfile() {
               Usar NFC para armazenar o perfil
             </label>
           </div>
-          <button type="submit" disabled={saving}>
+          <button className="btn" type="submit" disabled={saving}>
             {saving ? 'Salvando…' : 'Salvar Perfil'}
           </button>
         </form>

--- a/src/components/Intro.js
+++ b/src/components/Intro.js
@@ -21,8 +21,8 @@ export default function Intro() {
             para proteger pessoas de ingredientes perigosos. Descubra o que é seguro
             em cada fase e ajude a todos a comer sem medo!
           </p>
-          <button onClick={handleStart}>Iniciar Missão</button>
-          <button onClick={handleSkip}>Pular</button>
+          <button className="btn" onClick={handleStart}>Iniciar Missão</button>
+          <button className="btn" onClick={handleSkip}>Pular</button>
         </div>
       </div>
     </FadeIn>

--- a/src/components/PhaseTransition.js
+++ b/src/components/PhaseTransition.js
@@ -76,7 +76,7 @@ export default function PhaseTransition() {
         {text && <h2>{text}</h2>}
         {tip && <p>{tip}</p>}
         {allowSkip && (
-          <button onClick={handleSkip} style={{ marginTop: '1rem' }}>
+          <button className="btn" onClick={handleSkip} style={{ marginTop: '1rem' }}>
             Pular
           </button>
         )}

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -49,8 +49,8 @@ export default function Profile() {
             {selected.length > 0 ? selected.join(', ') : 'Nenhum'}
           </p>
           <div className="flex-gap">
-            <button onClick={() => navigate('/modes')}>Selecionar Fase</button>
-            <button onClick={() => navigate('/profile/edit')}>Editar perfil</button>
+            <button className="btn" onClick={() => navigate('/modes')}>Selecionar Fase</button>
+            <button className="btn" onClick={() => navigate('/profile/edit')}>Editar perfil</button>
           </div>
         </div>
       </PageLayout>

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -116,7 +116,7 @@ export default function RegisterForm() {
               Usar NFC para armazenar o perfil
             </label>
           </div>
-          <button type="submit" disabled={saving}>
+          <button className="btn" type="submit" disabled={saving}>
             {saving ? 'Salvando…' : 'Salvar Perfil'}
           </button>
         </form>

--- a/src/components/Tutorial.js
+++ b/src/components/Tutorial.js
@@ -65,7 +65,7 @@ export default function Tutorial() {
           />
           na parte superior da tela.
         </p>
-        <button onClick={() => navigate('/modes')}>Voltar</button>
+        <button className="btn" onClick={() => navigate('/modes')}>Voltar</button>
       </div>
     </PageLayout>
   );

--- a/src/index.css
+++ b/src/index.css
@@ -13,6 +13,33 @@ body {
   flex-direction: column;
 }
 
+/* Reusable button styling */
+.btn {
+  background-color: #0055aa;
+  color: #fff;
+  padding: 0.5rem 1rem;
+  border: none;
+  border-radius: 0.25rem;
+  cursor: pointer;
+  transition: background-color 0.3s ease, transform 0.1s ease;
+}
+
+.btn:hover:not(:disabled),
+.btn:focus:not(:disabled) {
+  background-color: #004080;
+}
+
+.btn:active:not(:disabled) {
+  background-color: #003366;
+  transform: scale(0.98);
+}
+
+.btn:disabled {
+  background-color: #6c757d;
+  color: #fff;
+  cursor: not-allowed;
+}
+
 .phase-grid {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- create global `.btn` class with high-contrast colors, padding, rounded corners and state transitions
- refactor intro, profile, registration, and other components to use the reusable button class

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68914bff9f9c832f846b34bbe558f8ab