### PR TITLE
feat: apply Poppins font across app

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -6,6 +6,12 @@
   <title>Chef Alerg</title>
   <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
   <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
+  <link rel="preconnect" href="https://fonts.googleapis.com" />
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link
+    href="https://fonts.googleapis.com/css2?family=Poppins:wght@400;600&display=swap"
+    rel="stylesheet"
+  />
 </head>
 <body>
   <noscript>Este app requer JavaScript para funcionar.</noscript>

--- a/src/index.css
+++ b/src/index.css
@@ -1,8 +1,25 @@
 body {
   margin: 0;
-  font-family: sans-serif;
+  font-family: 'Poppins', Arial, sans-serif;
   background-color: #fdfdfd;
   color: #333;
+}
+
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  font-family: 'Poppins', Arial, sans-serif;
+  font-weight: 600;
+  margin-top: 0;
+}
+
+p {
+  font-family: 'Poppins', Arial, sans-serif;
+  line-height: 1.6;
+  margin-top: 0;
 }
 
 #root {


### PR DESCRIPTION
## Summary
- import Poppins from Google Fonts
- apply Poppins to body, headings, and paragraphs for consistent typography

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_68914c00bd54832f8b294c08e49305fd