### PR TITLE
Improve UI responsiveness and item animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Jogo educativo casual de reflexo que desafia crianças e adultos a identificar e
 
 ## Demonstração
 
-![Chef Alerg GIF](https://user-images.githubusercontent.com/SEU_USUARIO/placeholder-chef-alerg.gif)
+![Chef Alerg Logo](src/assets/images/logo_chef_alerg.png)
 
 ---
 

--- a/src/utils/hudConfig.js
+++ b/src/utils/hudConfig.js
@@ -1,14 +1,15 @@
 export const getHUDConfig = (width, height) => {
-  const margin = width * 0.02;
-  const iconSize = width * 0.04;
+  const base = Math.min(width, height);
+  const margin = base * 0.02;
+  const iconSize = base * 0.04;
   return {
     margin,
     iconSize,
     textStyle: { fontSize: `${iconSize}px`, fill: '#fff' },
     tip: {
-      cardWidth: width * 0.375,
-      cardHeight: height * 0.166,
-      y: height - height * 0.166 - margin,
+      cardWidth: base * 0.75,
+      cardHeight: base * 0.25,
+      y: height - base * 0.25 - margin,
     },
   };
 };


### PR DESCRIPTION
## Summary
- replace placeholder demo image with project logo
- scale HUD and sprites relative to viewport
- animate item spawn and removal for lively gameplay

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_689358e04f20832f97575ee438edb22d