### PR TITLE
Fix item scaling when spawning and adjust phase scales

### DIFF
--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -14,7 +14,7 @@
   "itemSpawnRate": 1600,
   "duration": 60,
   "simultaneous": 1,
-  "itemScale": 0.09,
+  "itemScale": 0.07,
   "items": [
     {
       "key": "apple",

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -14,7 +14,7 @@
   "itemSpawnRate": 900,
   "duration": 80,
   "simultaneous": 3,
-  "itemScale": 0.1,
+  "itemScale": 0.07,
   "items": [
     {
       "key": "cake",

--- a/src/phases/praia.json
+++ b/src/phases/praia.json
@@ -15,7 +15,7 @@
   "itemSpawnRate": 700,
   "duration": 90,
   "simultaneous": 4,
-  "itemScale": 0.08,
+  "itemScale": 0.07,
   "items": [
     {
       "allergens": ["shellfish"],

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -14,7 +14,7 @@
   "itemSpawnRate": 1300,
   "duration": 70,
   "simultaneous": 2,
-  "itemScale": 0.09,
+  "itemScale": 0.07,
   "items": [
     {
       "key": "cookie",

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -198,12 +198,15 @@ export default class GameScene extends Phaser.Scene {
     const x = Phaser.Math.Between(itemSize / 2, width - itemSize / 2);
     const sprite = this.physics.add.image(x, -itemSize / 2, item.key);
     sprite.setDisplaySize(itemSize, itemSize);
+    const targetScaleX = sprite.scaleX;
+    const targetScaleY = sprite.scaleY;
     sprite.setScale(0);
     sprite.setData('itemData', item);
     sprite.setVelocityY(100 * this.speed);
     this.tweens.add({
       targets: sprite,
-      scale: { from: 0, to: 1 },
+      scaleX: { from: 0, to: targetScaleX },
+      scaleY: { from: 0, to: targetScaleY },
       duration: 300,
       ease: 'Back.Out',
     });


### PR DESCRIPTION
## Summary
- Ensure spawned items tween to their configured size by storing scaleX/scaleY after `setDisplaySize` and tweening to those values
- Reduce `itemScale` to 0.07 across phase configs to keep items proportionate

## Testing
- `npm test` (no tests found)


------
https://chatgpt.com/codex/tasks/task_b_6893e0757aec832f9d48265300f6623e