### PR TITLE
feat: pass game result to phase handler

### DIFF
--- a/src/components/MemoryGame.js
+++ b/src/components/MemoryGame.js
@@ -86,17 +86,21 @@ export default function MemoryGame() {
 
   const handleReturnToMenu = () => navigateWithTransition('Voltando ao menu...');
 
-  // Após o término de uma fase, destrava próxima fase e direciona para a tela de transição
-  const handlePhaseComplete = () => {
-    const idx = PHASES.findIndex((p) => p.key === phase);
-    const next = PHASES[idx + 1];
-    if (next && !unlockedPhases.includes(next.key)) {
-      unlockPhase(next.key);
-    }
-    if (next) {
-      navigate(`/transition/${next.key}`);
+  // Após o término de uma fase, destrava próxima fase somente em caso de sucesso
+  const handlePhaseComplete = (result) => {
+    if (result?.success) {
+      const idx = PHASES.findIndex((p) => p.key === phase);
+      const next = PHASES[idx + 1];
+      if (next && !unlockedPhases.includes(next.key)) {
+        unlockPhase(next.key);
+      }
+      if (next) {
+        navigate(`/transition/${next.key}`);
+      } else {
+        navigateWithTransition('Fim de jogo!');
+      }
     } else {
-      navigateWithTransition('Fim de jogo!');
+      navigateWithTransition('Tente novamente!');
     }
   };
 

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -175,15 +175,7 @@ export default class GameScene extends Phaser.Scene {
     });
     if (this.duration) {
       this.time.delayedCall(this.duration * 1000, () => {
-        this.scene.pause();
-        this.bgMusic.stop();
-        this.add
-          .text(width / 2, height / 2, 'Fim de Jogo', {
-            fontSize: '32px',
-            fill: '#f00',
-          })
-          .setOrigin(0.5);
-        if (typeof this.onGameOver === 'function') this.onGameOver();
+        this.endGame(true);
       });
     }
   }
@@ -308,7 +300,7 @@ export default class GameScene extends Phaser.Scene {
     });
   }
 
-  endGame() {
+  endGame(success = false) {
     this.scene.pause();
     this.bgMusic.stop();
     this.add
@@ -317,7 +309,7 @@ export default class GameScene extends Phaser.Scene {
         fill: '#f00',
       })
       .setOrigin(0.5);
-    if (typeof this.onGameOver === 'function') this.onGameOver();
+    if (typeof this.onGameOver === 'function') this.onGameOver({ success });
   }
 
   update() {


### PR DESCRIPTION
## Summary
- pass success flag when game ends to distinguish win/lose
- unlock and navigate to next phase only on successful completion

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_6893e080b734832fa6de04932c8f946d