### PR TITLE
fix: allow game canvas to fill remaining space

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -133,8 +133,8 @@ p {
 
 .game-container {
   width: 100%;
-  height: 100%;
   touch-action: none;
+  flex: 1;
 }
 
 .flex-gap {


### PR DESCRIPTION
## Summary
- remove fixed height from `.game-container`
- allow `.game-container` to grow with `flex: 1`

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6893f9ec5d18832f9ed31048c7d680fb