### PR TITLE
feat: adjust scene elements on resize

### DIFF
--- a/src/gameEngine.js
+++ b/src/gameEngine.js
@@ -40,6 +40,9 @@ export default class PhaserGameEngine {
     this.resizeHandler = () => {
       const { width: newWidth, height: newHeight } = parent.getBoundingClientRect();
       this.game.scale.resize(newWidth, newHeight);
+      this.game.scene.getScenes(true).forEach((scene) => {
+        scene.events.emit('resize', newWidth, newHeight);
+      });
     };
     window.addEventListener('resize', this.resizeHandler);
   }

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -153,7 +153,7 @@ export default class GameScene extends Phaser.Scene {
       .setDisplaySize(chefSize, chefSize);
     this.tipTimer = null;
     // Pause
-    const pauseButton = this.add
+    this.pauseButton = this.add
       .image(width - margin * 2, margin * 2, 'uiPause')
       .setDisplaySize(iconSize, iconSize)
       .setInteractive();
@@ -162,7 +162,7 @@ export default class GameScene extends Phaser.Scene {
       this.scene.launch('PauseScene');
       this.scene.pause();
     };
-    pauseButton.on('pointerdown', launchPause);
+    this.pauseButton.on('pointerdown', launchPause);
     this.input.keyboard.on('keydown-P', launchPause);
     this.spawnLoop = this.time.addEvent({
       delay: this.spawnRate,
@@ -178,6 +178,65 @@ export default class GameScene extends Phaser.Scene {
         this.endGame(true);
       });
     }
+
+    this.scale.on('resize', this.handleResize, this);
+    this.events.on('resize', this.handleResize, this);
+  }
+
+  handleResize(arg1, arg2) {
+    let width;
+    let height;
+    if (typeof arg1 === 'object') {
+      ({ width, height } = arg1);
+    } else {
+      width = arg1;
+      height = arg2;
+    }
+    if (typeof width !== 'number' || typeof height !== 'number') return;
+
+    const base = Math.min(width, height);
+    const chefSize = base * 0.15;
+    const hud = getHUDConfig(width, height);
+    const { margin, iconSize, textStyle, tip } = hud;
+
+    this.scoreContainer?.setPosition(margin, margin);
+    this.scoreIcon?.setDisplaySize(iconSize, iconSize);
+    this.scoreText?.setPosition(iconSize + margin / 2, 0).setStyle(textStyle);
+
+    this.livesContainer?.setPosition(width - margin, margin);
+    this.lifeIcons.forEach((icon, index) => {
+      icon
+        .setDisplaySize(iconSize, iconSize)
+        .setPosition(-index * (iconSize + margin / 2), 0);
+    });
+
+    if (this.timeContainer) {
+      this.timeContainer.setPosition(width / 2, margin);
+      this.timeIcon
+        .setDisplaySize(iconSize, iconSize)
+        .setPosition(-iconSize - margin / 2, 0);
+      this.timeText.setPosition(0, 0).setStyle(textStyle);
+    }
+
+    this.pauseButton
+      ?.setPosition(width - margin * 2, margin * 2)
+      .setDisplaySize(iconSize, iconSize);
+
+    this.tipCard
+      ?.setPosition(width / 2, tip.y)
+      .setDisplaySize(tip.cardWidth, tip.cardHeight);
+    this.tipText
+      ?.setPosition(width / 2, tip.y)
+      .setStyle({
+        fontSize: `${iconSize * 0.6}px`,
+        fill: '#000',
+        align: 'center',
+        wordWrap: { width: tip.cardWidth - margin * 2 },
+      });
+
+    this.chef
+      ?.setDisplaySize(chefSize, chefSize)
+      .setPosition(width / 2, height - chefSize / 2 - margin * 2);
   }
 
   spawnItem() {


### PR DESCRIPTION
## Summary
- handle scene resize by recalculating HUD and chef positions
- emit resize events from game engine

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6893fa0371cc832fbe12180390e46236