### PR TITLE
Use dynamic viewport height for root element

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -23,7 +23,8 @@ p {
 }
 
 #root {
-  height: 100vh;
+  min-height: 100vh;
+  height: 100dvh;
   width: 100vw;
   overflow: hidden;
   display: flex;


### PR DESCRIPTION
## Summary
- make root element use 100dvh with 100vh fallback to match visible screen height on mobile

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_6893fa275304832f922708f21047242e