### PR TITLE
refactor: replace allergens with gluten sources

### DIFF
--- a/src/components/EditProfile.js
+++ b/src/components/EditProfile.js
@@ -4,10 +4,10 @@ import { saveProfile } from '../services/firestore';
 import { saveNfcPreference } from '../utils/storage';
 import { arrayToBitmask, bitmaskToArray } from '../utils/bitmask';
 import { useStore } from '../store';
-import { ALLERGEN_NAMES } from '../constants/allergens';
+import { GLUTEN_SOURCES } from '../constants/allergens';
 import PageLayout from './PageLayout';
 
-// Lista de alérgenos importada de src/constants/allergens.js. A ordem deve ser mantida.
+// Lista de fontes de glúten importada de src/constants/allergens.js. A ordem deve ser mantida.
 
 export default function EditProfile() {
   const navigate = useNavigate();
@@ -17,7 +17,7 @@ export default function EditProfile() {
   const [nome, setNome] = useState(profile?.nome || '');
   const [idade, setIdade] = useState(profile?.idade ?? '');
   const [selectedBits, setSelectedBits] = useState(
-    profile ? bitmaskToArray(profile.bitmask, profile.bitCount || ALLERGEN_NAMES.length) : []
+    profile ? bitmaskToArray(profile.bitmask, profile.bitCount || GLUTEN_SOURCES.length) : []
   );
   const [useNfc, setUseNfc] = useState(false);
   const [saving, setSaving] = useState(false);
@@ -27,7 +27,7 @@ export default function EditProfile() {
     return null;
   }
 
-  const toggleAlergeno = (index) => {
+  const toggleFonte = (index) => {
     setSelectedBits((prev) => {
       if (prev.includes(index)) {
         return prev.filter((bit) => bit !== index);
@@ -92,15 +92,15 @@ export default function EditProfile() {
             </label>
           </div>
           <div className="form-group">
-            <strong>Selecione seus alérgenos:</strong>
+            <strong>Selecione as fontes de glúten:</strong>
             <ul className="list-unstyled">
-              {ALLERGEN_NAMES.map((name, idx) => (
+              {GLUTEN_SOURCES.map((name, idx) => (
                 <li key={idx}>
                   <label>
                     <input
                       type="checkbox"
                       checked={selectedBits.includes(idx)}
-                      onChange={() => toggleAlergeno(idx)}
+                      onChange={() => toggleFonte(idx)}
                     />
                     {name}
                   </label>

--- a/src/components/Profile.js
+++ b/src/components/Profile.js
@@ -3,12 +3,12 @@ import { useNavigate } from 'react-router-dom';
 import { loadProfile } from '../services/firestore';
 import { useStore } from '../store';
 import LoadingScreen from './LoadingScreen';
-import { ALLERGEN_NAMES } from '../constants/allergens';
+import { GLUTEN_SOURCES } from '../constants/allergens';
 import NavBar from './NavBar';
 import PageLayout from './PageLayout';
 
 /**
- * Displays the saved user profile along with a list of allergens to avoid.
+ * Displays the saved user profile along with a list of gluten sources to avoid.
  */
 export default function Profile() {
   const profile = useStore((s) => s.profile);
@@ -28,9 +28,9 @@ export default function Profile() {
     return <LoadingScreen />;
   }
 
-  // Compute a list of allergens from the bitmask for display.
-  const bitCount = profile.bitCount || ALLERGEN_NAMES.length;
-  const selected = ALLERGEN_NAMES.slice(0, bitCount).filter((_, idx) => (profile.bitmask & (1 << idx)) !== 0);
+  // Compute a list of gluten sources from the bitmask for display.
+  const bitCount = profile.bitCount || GLUTEN_SOURCES.length;
+  const selected = GLUTEN_SOURCES.slice(0, bitCount).filter((_, idx) => (profile.bitmask & (1 << idx)) !== 0);
 
   return (
     <>
@@ -45,7 +45,7 @@ export default function Profile() {
             <strong>Idade:</strong> {profile.idade}
           </p>
           <p>
-            <strong>Alérgenos selecionados:</strong>{' '}
+            <strong>Fontes de glúten selecionadas:</strong>{' '}
             {selected.length > 0 ? selected.join(', ') : 'Nenhum'}
           </p>
           <div className="flex-gap">

--- a/src/components/RegisterForm.js
+++ b/src/components/RegisterForm.js
@@ -3,10 +3,10 @@ import { useNavigate } from 'react-router-dom';
 import { saveProfile } from '../services/firestore';
 import { saveNfcPreference } from '../utils/storage';
 import { arrayToBitmask } from '../utils/bitmask';
-import { ALLERGEN_NAMES } from '../constants/allergens';
+import { GLUTEN_SOURCES } from '../constants/allergens';
 import PageLayout from './PageLayout';
 
-// Lista de alérgenos importada de src/constants/allergens.js. A ordem deve ser mantida.
+// Lista de fontes de glúten importada de src/constants/allergens.js. A ordem deve ser mantida.
 
 // Gera um UID simples combinando timestamp e número aleatório.
 const generateUid = () => {
@@ -25,7 +25,7 @@ export default function RegisterForm() {
   const [useNfc, setUseNfc] = useState(false);
   const [saving, setSaving] = useState(false);
 
-  const toggleAlergeno = (index) => {
+  const toggleFonte = (index) => {
     setSelectedBits((prev) => {
       if (prev.includes(index)) {
         return prev.filter((bit) => bit !== index);
@@ -90,15 +90,15 @@ export default function RegisterForm() {
             </label>
           </div>
           <div className="form-group">
-            <strong>Selecione seus alérgenos:</strong>
+            <strong>Selecione as fontes de glúten:</strong>
             <ul className="list-unstyled">
-              {ALLERGEN_NAMES.map((name, idx) => (
+              {GLUTEN_SOURCES.map((name, idx) => (
                 <li key={idx}>
                   <label>
                     <input
                       type="checkbox"
                       checked={selectedBits.includes(idx)}
-                      onChange={() => toggleAlergeno(idx)}
+                      onChange={() => toggleFonte(idx)}
                     />
                     {name}
                   </label>

--- a/src/constants/allergens.js
+++ b/src/constants/allergens.js
@@ -1,15 +1,8 @@
-// Lista de alérgenos. A ordem corresponde aos bits armazenados no perfil.
-export const ALLERGEN_NAMES = [
-  'Leite',
-  'Ovo',
-  'Amendoim',
-  'Soja',
+// Fontes de glúten. A ordem corresponde aos bits armazenados no perfil.
+// Atualmente o bitmask representa apenas essas fontes de glúten, mantendo a estrutura para futuras expansões.
+export const GLUTEN_SOURCES = [
   'Trigo',
-  'Peixes',
-  'Frutos do Mar',
-  'Castanhas',
-  'Milho',
-  'Coco',
-  'Abacaxi',
-  'Morango',
+  'Cevada',
+  'Centeio',
+  'Aveia (contaminação)',
 ];


### PR DESCRIPTION
## Summary
- focus allergen bitmask on gluten-only sources
- adjust profile and forms to display gluten-specific options

## Testing
- `CI=true npm test`

------
https://chatgpt.com/codex/tasks/task_b_6895e48f3fb0832f834b4c34cc0b5a50