### PR TITLE
Add gluten flags and educational tips

### DIFF
--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -2,7 +2,7 @@
   "transition": {
     "text": "Bem-vindo à Feira!",
     "image": "/assets/images/bg/feira_day.png",
-    "tip": "Dica: fique atento aos itens perigosos!",
+    "tip": "Dica: alguns produtos na feira podem conter glúten escondido!",
     "audio": "/assets/audio/safe.ogg",
     "duration": 4000,
     "skipAfter": 2000,
@@ -24,31 +24,31 @@
       "key": "banana",
       "spriteUrl": "/assets/images/items/banana.png",
       "trap": true,
-      "penalty": 5
+      "penalty": 5,
+      "crossContamination": true
     },
     {
-      "key": "peanut",
-      "spriteUrl": "/assets/images/items/peanut.png",
-      "bitmaskBit": 2
+      "key": "bread",
+      "spriteUrl": "/assets/images/items/bread.png",
+      "containsGluten": true
     },
     {
-      "key": "hazelnut",
-      "spriteUrl": "/assets/images/items/hazelnut.png",
-      "bitmaskBit": 7
+      "key": "wheat",
+      "spriteUrl": "/assets/images/items/wheat.png",
+      "containsGluten": true
     },
     {
-      "key": "soybean",
-      "spriteUrl": "/assets/images/items/soybean.png",
-      "bitmaskBit": 3
+      "key": "pineapple",
+      "spriteUrl": "/assets/images/items/pineapple.png"
     },
     {
       "key": "strawberry",
       "spriteUrl": "/assets/images/items/strawberry.png",
-      "bitmaskBit": 11
+      "crossContamination": true
     }
   ],
   "tips": [
-    "Amendoim e soja são alergênicos comuns na feira.",
-    "Fique de olho em castanhas escondidas em doces."
+    "Pães e farinhas expostas carregam muito glúten.",
+    "Frutas cortadas com utensílios usados em massas podem contaminar."
   ]
 }

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -6,7 +6,7 @@
     "audio": "/assets/audio/safe.ogg",
     "duration": 3000,
     "skipAfter": 2000,
-    "tip": "Dica: cuidado com ingredientes escondidos nos doces!"
+    "tip": "Dica: doces podem esconder glúten nas receitas!"
   },
   "background": "/assets/images/bg/festa.png",
   "music": "/assets/audio/background.ogg",
@@ -19,36 +19,35 @@
     {
       "key": "cake",
       "spriteUrl": "/assets/images/items/cake.png",
-      "bitmaskBit": 1
+      "containsGluten": true
     },
     {
       "key": "icecream",
       "spriteUrl": "/assets/images/items/icecream.png",
-      "bitmaskBit": 0
+      "crossContamination": true
     },
     {
-      "key": "chocolate",
-      "spriteUrl": "/assets/images/items/chocolate.png",
-      "bitmaskBit": 2
+      "key": "cookie",
+      "spriteUrl": "/assets/images/items/cookie.png",
+      "containsGluten": true
     },
     {
       "key": "candy",
       "spriteUrl": "/assets/images/items/candy.png"
     },
     {
-      "key": "coconut",
-      "spriteUrl": "/assets/images/items/coconut.png",
-      "bitmaskBit": 9
+      "key": "chocolate",
+      "spriteUrl": "/assets/images/items/chocolate.png",
+      "crossContamination": true
     },
     {
       "key": "strawberry",
       "spriteUrl": "/assets/images/items/strawberry.png",
-      "bitmaskBit": 11,
       "bonus": 20
     }
   ],
   "tips": [
-    "Bolos e sorvetes quase sempre contêm leite e ovos.",
-    "Doces coloridos podem ter traços de amendoim."
+    "Bolos e biscoitos são ricos em glúten.",
+    "Utilize utensílios limpos para evitar contaminação cruzada."
   ]
 }

--- a/src/phases/praia.json
+++ b/src/phases/praia.json
@@ -7,7 +7,7 @@
     "audio": "/assets/audio/safe.ogg",
     "duration": 3000,
     "skipAfter": 2000,
-    "tip": "Dica: frutos do mar podem conter alérgenos!"
+    "tip": "Dica: empanados de praia podem conter farinha!"
   },
   "background": "/assets/images/bg/praia.png",
   "music": "/assets/audio/beach_loop.mp3",
@@ -18,47 +18,39 @@
   "itemScale": 0.07,
   "items": [
     {
-      "allergens": ["shellfish"],
       "key": "shrimp",
       "spriteUrl": "/assets/images/items/shrimp.png",
-      "bitmaskBit": 6
+      "crossContamination": true
     },
     {
-      "allergens": ["fish"],
       "key": "fish",
       "spriteUrl": "/assets/images/items/fish.png",
-      "bitmaskBit": 5
+      "crossContamination": true
     },
     {
-      "allergens": ["shellfish"],
       "key": "squid",
       "spriteUrl": "/assets/images/items/squid.png",
-      "bitmaskBit": 6,
+      "crossContamination": true,
       "trap": true,
       "penalty": 5
     },
     {
-      "allergens": ["coconut"],
-      "key": "coconut",
-      "spriteUrl": "/assets/images/items/coconut.png",
-      "bitmaskBit": 9
-    },
-    {
-      "allergens": ["gluten", "egg", "milk"],
       "key": "cake",
       "spriteUrl": "/assets/images/items/cake.png",
-      "bitmaskBit": 1
+      "containsGluten": true
     },
     {
-      "allergens": ["pineapple"],
+      "key": "coconut",
+      "spriteUrl": "/assets/images/items/coconut.png"
+    },
+    {
       "key": "pineapple",
       "spriteUrl": "/assets/images/items/pineapple.png",
-      "bitmaskBit": 10,
       "bonus": 15
     }
   ],
   "tips": [
-    "Frutos do mar são a causa nº1 de anafilaxia na praia!",
-    "Cuidado: bolos quase sempre têm ovo e leite."
+    "Frituras empanadas costumam usar farinha de trigo.",
+    "Separe petiscos 'sem glúten' de outros utensílios."
   ]
 }

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -6,7 +6,7 @@
     "audio": "/assets/audio/safe.ogg",
     "duration": 3000,
     "skipAfter": 2000,
-    "tip": "Dica: leia os rótulos com atenção!"
+    "tip": "Dica: procure rótulos 'sem glúten' nos produtos!"
   },
   "background": "/assets/images/bg/supermercado.png",
   "music": "/assets/audio/background.ogg",
@@ -19,44 +19,41 @@
     {
       "key": "cookie",
       "spriteUrl": "/assets/images/items/cookie.png",
-      "bitmaskBit": 1
+      "containsGluten": true
     },
     {
       "key": "milk",
-      "spriteUrl": "/assets/images/items/milk.png",
-      "bitmaskBit": 0
+      "spriteUrl": "/assets/images/items/milk.png"
     },
     {
       "key": "bread",
       "spriteUrl": "/assets/images/items/bread.png",
-      "bitmaskBit": 4,
+      "containsGluten": true,
       "trap": true,
       "penalty": 10
     },
     {
       "key": "cereal",
       "spriteUrl": "/assets/images/items/cereal.png",
-      "bitmaskBit": 8
+      "containsGluten": true
     },
     {
       "key": "cheese",
       "spriteUrl": "/assets/images/items/cheese.png",
-      "bitmaskBit": 0
+      "crossContamination": true
     },
     {
       "key": "egg",
-      "spriteUrl": "/assets/images/items/egg.png",
-      "bitmaskBit": 1
+      "spriteUrl": "/assets/images/items/egg.png"
     },
     {
       "key": "pineapple",
       "spriteUrl": "/assets/images/items/pineapple.png",
-      "bitmaskBit": 10,
       "bonus": 15
     }
   ],
   "tips": [
-    "Leia os rótulos para evitar glúten e lactose.",
-    "Produtos industrializados podem esconder alergênicos."
+    "Leia os rótulos e procure por produtos com selo 'sem glúten'.",
+    "Itens a granel podem ter contato com farinhas."
   ]
 }

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -289,9 +289,7 @@ export default class GameScene extends Phaser.Scene {
 
   handleItemClick(sprite) {
     const item = sprite.getData('itemData');
-    const bit = item.bitmaskBit;
-    const isAllergen =
-      typeof bit === 'number' && (this.bitmask & (1 << bit)) !== 0;
+    const isAllergen = item.containsGluten || item.crossContamination;
     const correct = !isAllergen && !item.trap;
     if (isAllergen) {
       this.animateChef('miss');


### PR DESCRIPTION
## Summary
- Replace `bitmaskBit` values with `containsGluten` and `crossContamination` flags across all phase configs
- Expand phase item lists with gluten foods like bread and cookies plus naturally gluten-free options
- Update gameplay logic to evaluate new gluten flags and revise level tips with hidden-gluten advice

## Testing
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_b_6895e492bb78832f8a701f6522bcf03e