### PR TITLE
Add transition instructions and advanced item handling

### DIFF
--- a/src/components/PhaseTransition.js
+++ b/src/components/PhaseTransition.js
@@ -56,7 +56,7 @@ export default function PhaseTransition() {
   if (!config) return null;
 
   const transition = { ...DEFAULT_TRANSITION, ...(config.transition || {}) };
-  const { text, image, tip, animation, video } = transition;
+  const { text, image, tip, animation, video, instructions } = transition;
 
   return (
     <TransitionScreen
@@ -74,6 +74,7 @@ export default function PhaseTransition() {
           />
         )}
         {text && <h2>{text}</h2>}
+        {instructions && <p style={{ fontStyle: 'italic' }}>{instructions}</p>}
         {tip && <p>{tip}</p>}
         {allowSkip && (
           <button className="btn" onClick={handleSkip} style={{ marginTop: '1rem' }}>

--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -6,7 +6,8 @@
     "audio": "/assets/audio/safe.ogg",
     "duration": 4000,
     "skipAfter": 2000,
-    "animation": "slide"
+    "animation": "slide",
+    "instructions": "Na Feira, colete frutas e legumes seguros. Evite itens com glúten como pães, trigo e produtos que possam estar contaminados. Fique atento aos ícones explosivos e itens bônus passando!"
   },
   "background": "/assets/images/bg/feira_day.png",
   "music": "/assets/audio/background.ogg",
@@ -30,7 +31,8 @@
     {
       "key": "bread",
       "spriteUrl": "/assets/images/items/bread.png",
-      "containsGluten": true
+      "containsGluten": true,
+      "labelUrl": "/assets/images/items/bread.png"
     },
     {
       "key": "wheat",

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -6,7 +6,8 @@
     "audio": "/assets/audio/safe.ogg",
     "duration": 3000,
     "skipAfter": 2000,
-    "tip": "Dica: doces podem esconder glúten nas receitas!"
+    "tip": "Dica: doces podem esconder glúten nas receitas!",
+    "instructions": "Na Festa de Aniversário, muitos doces e bolos contêm glúten. Clique somente em itens seguros e fique atento a itens que se movem rapidamente, pois podem ser bônus!"
   },
   "background": "/assets/images/bg/festa.png",
   "music": "/assets/audio/background.ogg",
@@ -19,7 +20,8 @@
     {
       "key": "cake",
       "spriteUrl": "/assets/images/items/cake.png",
-      "containsGluten": true
+      "containsGluten": true,
+      "labelUrl": "/assets/images/items/cake.png"
     },
     {
       "key": "icecream",
@@ -33,7 +35,11 @@
     },
     {
       "key": "candy",
-      "spriteUrl": "/assets/images/items/candy.png"
+      "spriteUrl": "/assets/images/items/candy.png",
+      "runner": true,
+      "direction": "right",
+      "speed": 200,
+      "bonus": 5
     },
     {
       "key": "chocolate",

--- a/src/phases/praia.json
+++ b/src/phases/praia.json
@@ -7,7 +7,8 @@
     "audio": "/assets/audio/safe.ogg",
     "duration": 3000,
     "skipAfter": 2000,
-    "tip": "Dica: empanados de praia podem conter farinha!"
+    "tip": "Dica: empanados de praia podem conter farinha!",
+    "instructions": "Na Praia, muita comida frita é empanada com farinha de trigo. Clique apenas em frutas frescas e bebidas seguras. Alguns itens podem mover-se rapidamente trazendo bônus ou armadilhas."
   },
   "background": "/assets/images/bg/praia.png",
   "music": "/assets/audio/beach_loop.mp3",

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -6,7 +6,8 @@
     "audio": "/assets/audio/safe.ogg",
     "duration": 3000,
     "skipAfter": 2000,
-    "tip": "Dica: procure rótulos 'sem glúten' nos produtos!"
+    "tip": "Dica: procure rótulos 'sem glúten' nos produtos!",
+    "instructions": "No Supermercado, leia atentamente os rótulos e clique apenas em produtos sem glúten. Itens com selo 'sem glúten' são seguros. Tenha cuidado com contaminação cruzada e com itens explosivos!"
   },
   "background": "/assets/images/bg/supermercado.png",
   "music": "/assets/audio/background.ogg",
@@ -50,6 +51,12 @@
       "key": "pineapple",
       "spriteUrl": "/assets/images/items/pineapple.png",
       "bonus": 15
+    },
+    {
+      "key": "hazelnut",
+      "spriteUrl": "/assets/images/items/hazelnut.png",
+      "explosive": true,
+      "penalty": 15
     }
   ],
   "tips": [


### PR DESCRIPTION
## Summary
- extend phase data with instructions and special item flags
- show instructions on phase transition screen
- support label inspection, runner, and explosive items in game scene

## Testing
- `npm test -- --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_b_68967d8b21b0832fb9df8e5c84153248