### PR TITLE
Track label reading time

### DIFF
--- a/GameScene.js
+++ b/GameScene.js
@@ -503,6 +503,7 @@ export default class GameScene extends Phaser.Scene {
    * processed as usual via processItem().
    */
   showLabel(item, sprite) {
+    this.labelTimerStart = this.time.now;
     // Draw semi-transparent backdrop
     const overlay = this.add.rectangle(
       this.scale.width / 2,
@@ -528,6 +529,7 @@ export default class GameScene extends Phaser.Scene {
     this.time.delayedCall(2500, () => {
       overlay.destroy();
       labelImage.destroy();
+      this.recordLabelTime();
       this.processItem(item, sprite);
     });
   }


### PR DESCRIPTION
## Summary
- track label viewing time by starting a timer when the label shows and recording on close
- route item clicks through label display before processing

## Testing
- `CI=true npm test`
- `node - <<'NODE'
class DummyScene {
  constructor() {
    this.time = { now: 0 };
    this.tempoLeituraRotulo = [];
    this.labelTimerStart = null;
  }
  recordLabelTime() {
    if (this.labelTimerStart != null) {
      const elapsed = (this.time.now - this.labelTimerStart) / 1000;
      this.tempoLeituraRotulo.push(elapsed);
      this.labelTimerStart = null;
    }
  }
}
const s = new DummyScene();
s.labelTimerStart = 0;
s.time.now = 1000;
s.recordLabelTime();
s.labelTimerStart = 2000;
s.time.now = 5000;
s.recordLabelTime();
console.log(s.tempoLeituraRotulo);
NODE`

------
https://chatgpt.com/codex/tasks/task_b_68967d576b18832fb0603923dea85cce