### PR TITLE
Add unit test for GameScene recordLabelTime

### DIFF
--- a/src/scenes/__tests__/GameScene.test.js
+++ b/src/scenes/__tests__/GameScene.test.js
@@ -1,0 +1,17 @@
+import GameScene from '../GameScene';
+
+jest.mock('phaser', () => ({
+  __esModule: true,
+  default: { Scene: class {} }
+}));
+
+describe('GameScene recordLabelTime', () => {
+  it('records elapsed time since labelTimerStart', () => {
+    const scene = new GameScene({ phaseConfig: { items: [] } });
+    scene.labelTimerStart = 1000;
+    scene.time = { now: 4000 };
+    scene.recordLabelTime();
+    expect(scene.tempoLeituraRotulo).toEqual([3]);
+    expect(scene.labelTimerStart).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- add GameScene test verifying recordLabelTime pushes elapsed time to metrics

## Testing
- `CI=true npm test src/scenes/__tests__/GameScene.test.js`

------
https://chatgpt.com/codex/tasks/task_b_689686e5b8d4832f92e47f19df708c62