### PR TITLE
Increase item scale across phase configs

### DIFF
--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -15,7 +15,7 @@
   "itemSpawnRate": 1600,
   "duration": 60,
   "simultaneous": 1,
-  "itemScale": 0.07,
+  "itemScale": 0.15,
   "items": [
     {
       "key": "apple",

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -15,7 +15,7 @@
   "itemSpawnRate": 900,
   "duration": 80,
   "simultaneous": 3,
-  "itemScale": 0.07,
+  "itemScale": 0.15,
   "items": [
     {
       "key": "cake",

--- a/src/phases/praia.json
+++ b/src/phases/praia.json
@@ -16,7 +16,7 @@
   "itemSpawnRate": 700,
   "duration": 90,
   "simultaneous": 4,
-  "itemScale": 0.07,
+  "itemScale": 0.15,
   "items": [
     {
       "key": "shrimp",

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -15,7 +15,7 @@
   "itemSpawnRate": 1300,
   "duration": 70,
   "simultaneous": 2,
-  "itemScale": 0.07,
+  "itemScale": 0.15,
   "items": [
     {
       "key": "cookie",


### PR DESCRIPTION
## Summary
- enlarge item scale for Feira, Festa, Praia and Supermercado phases

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897373fc910832f9eda8b9e9757b1d8