### PR TITLE
Increase item scale across phase configs and enlarge chef

### DIFF
--- a/src/phases/feira.json
+++ b/src/phases/feira.json
@@ -15,7 +15,7 @@
   "itemSpawnRate": 1600,
   "duration": 60,
   "simultaneous": 1,
-  "itemScale": 0.07,
+  "itemScale": 0.15,
   "items": [
     {
       "key": "apple",

--- a/src/phases/festa.json
+++ b/src/phases/festa.json
@@ -15,7 +15,7 @@
   "itemSpawnRate": 900,
   "duration": 80,
   "simultaneous": 3,
-  "itemScale": 0.07,
+  "itemScale": 0.15,
   "items": [
     {
       "key": "cake",

--- a/src/phases/praia.json
+++ b/src/phases/praia.json
@@ -16,7 +16,7 @@
   "itemSpawnRate": 700,
   "duration": 90,
   "simultaneous": 4,
-  "itemScale": 0.07,
+  "itemScale": 0.15,
   "items": [
     {
       "key": "shrimp",

--- a/src/phases/supermercado.json
+++ b/src/phases/supermercado.json
@@ -15,7 +15,7 @@
   "itemSpawnRate": 1300,
   "duration": 70,
   "simultaneous": 2,
-  "itemScale": 0.07,
+  "itemScale": 0.15,
   "items": [
     {
       "key": "cookie",

--- a/src/scenes/GameScene.js
+++ b/src/scenes/GameScene.js
@@ -86,7 +86,7 @@ export default class GameScene extends Phaser.Scene {
     const base = Math.max(height, 320);
     const { phaseConfig, engine } = this;
 
-    const chefSize = Math.max(base * 0.15, 32);
+    const chefSize = Math.max(base * 0.3, 32);
     this.hud = getHUDConfig(width, height, chefSize);
     const { margin, iconSize, textStyle } = this.hud;
 
@@ -209,7 +209,7 @@ export default class GameScene extends Phaser.Scene {
   handleResize(gameSize) {
     const { width, height } = gameSize;
     const base = Math.max(height, 320);
-    const chefSize = Math.max(base * 0.15, 32);
+    const chefSize = Math.max(base * 0.3, 32);
 
     this.hud = getHUDConfig(width, height, chefSize);
     const { margin, iconSize, textStyle } = this.hud;


### PR DESCRIPTION
## Summary
- enlarge item scale for Feira, Festa, Praia and Supermercado phases
- make Chef Alerg character larger by scaling at 30% of base height

## Testing
- `CI=true npm test`


------
https://chatgpt.com/codex/tasks/task_b_6897373fc910832f9eda8b9e9757b1d8